### PR TITLE
fix(codex): suppress approval prompts via launch args + per-call tool args

### DIFF
--- a/config/coding_agents/codex/config.toml
+++ b/config/coding_agents/codex/config.toml
@@ -1,2 +1,0 @@
-approval_policy = "never"
-sandbox_mode = "workspace-write"

--- a/config/coding_agents/codex/config.toml.erb
+++ b/config/coding_agents/codex/config.toml.erb
@@ -1,0 +1,5 @@
+approval_policy = "never"
+sandbox_mode = "workspace-write"
+
+[sandbox_workspace_write]
+writable_roots = ["<%= ENV['HOME'] %>/ghq"]

--- a/config/coding_agents/mcp.json.erb
+++ b/config/coding_agents/mcp.json.erb
@@ -33,7 +33,11 @@
     },
     "codex": {
       "command": "codex",
-      "args": ["mcp-server"]
+      "args": [
+        "mcp-server",
+        "-c", "approval_policy=\"never\"",
+        "-c", "sandbox_mode=\"workspace-write\""
+      ]
     }
   }
 }

--- a/config/coding_agents/user-rules.md
+++ b/config/coding_agents/user-rules.md
@@ -87,12 +87,25 @@ yui は会話履歴の圧縮版である。LLM は会話が終われば全てを
 ```
 mcp__codex__codex(
   prompt="<具体的なタスク指示。対象ファイル・期待する結果・制約を明示>",
-  base-instructions="<プロジェクト固有のコンテキスト。DDD構造、命名規約、言語/FWルール等>"
+  base-instructions="<プロジェクト固有のコンテキスト。DDD構造、命名規約、言語/FWルール等>",
+  cwd="<作業対象プロジェクトの絶対パス>",
+  approval-policy="never",
+  sandbox="workspace-write"
 )
 ```
 
 - `base-instructions` には `AGENTS.md` / `CLAUDE.md` の抜粋や関連ファイルパスを渡す。Codex は Claude のルールを自動では読まない。
 - 移譲後は Codex の出力を検証してユーザーに報告する。Codex の回答を鵜呑みにして追加編集をせず転記するのは禁止。
+
+#### 呼び出し時の必須引数（承認プロンプト抑止のため）
+
+`cwd` / `approval-policy` / `sandbox` の 3 つは毎回明示的に渡せ。理由：
+
+- `codex mcp-server` は起動時の `-c approval_policy=never` や `~/.codex/config.toml` の設定を MCP 経路の承認判定に正しく伝播できないバグがあり（openai/codex#17238, #18268, #11816）、設定だけでは親ホスト（Claude Code 等）に escalation プロンプトが surface してしまう。
+- 同サーバーは **MCP tool call の引数を起動時 config より優先**する設計のため、引数で上書きすれば確実に効く。
+- `cwd` は tool 側の sandbox workspace の基点になる。対象リポジトリのルート絶対パスを渡す（相対パスは MCP サーバーの CWD 基準になり混乱を招く）。
+- `approval-policy` はデフォルト `"never"`、`sandbox` はデフォルト `"workspace-write"` とする。workspace 外パスを触る必要があるときのみ `sandbox="danger-full-access"` に昇格を検討し、その旨をユーザに確認する。
+- `writable_roots` は `~/.codex/config.toml`（dotfiles: `config/coding_agents/codex/config.toml.erb`）で `$HOME/ghq` を通してあるので、ghq 配下のリポジトリ間で参照・書き込みが必要なコマンドは追加設定なしで通る想定。
 
 ## スキル（必要時のみ参照せよ）
 

--- a/roles/base/default.rb
+++ b/roles/base/default.rb
@@ -56,7 +56,21 @@ dotfile '.claude/render-diagram.sh' => 'coding_agents/claude/render-diagram.sh'
 
 # Codex-specific
 dotfile '.codex/AGENTS.md' => 'coding_agents/codex/AGENTS.md'
-dotfile '.codex/config.toml' => 'coding_agents/codex/config.toml'
+
+codex_config_erb = File.join(root_dir, 'config/coding_agents/codex/config.toml.erb')
+
+directory "#{ENV['HOME']}/.codex" do
+  user node[:user]
+end
+
+execute "rm -f #{ENV['HOME']}/.codex/config.toml" do
+  only_if "test -L #{ENV['HOME']}/.codex/config.toml"
+end
+template "#{ENV['HOME']}/.codex/config.toml" do
+  source codex_config_erb
+  user node[:user]
+  mode '0644'
+end
 
 # MCP settings (template generates both Cursor and Claude Code configs)
 mcp_erb = File.join(root_dir, 'config/coding_agents/mcp.json.erb')


### PR DESCRIPTION
## Summary

承認プロンプトが消えない問題に対する 2 段階の対策を束ねた PR。

### 第 1 弾 (2fa4e0e): MCP server 起動時引数で config を上書き
- `~/.codex/config.toml` に `approval_policy = "never"` を書いても、`codex mcp-server` セッションでは `approval_policy = "on-failure"` が使われ、承認プロンプトが発生していた
- セッションログで確認: `"approval_policy":"on-failure"`（`sandbox_policy` は config.toml が反映されていたが approval_policy のみ無視）
- `mcp.json` の `args` に `-c approval_policy="never"` / `-c sandbox_mode="workspace-write"` を渡してサーバー起動時に明示

### 第 2 弾 (3870391): tool call 引数で上書き + writable_roots
第 1 弾で設定しても MCP 経由の承認パスで escalation プロンプトが残る事象が発生。openai/codex 側の既知バグに該当:
- [openai/codex#17238](https://github.com/openai/codex/pull/17238) `[mcp] Respect -a never for mcp tool call approvals` (未マージ)
- [openai/codex#18268](https://github.com/openai/codex/issues/18268) elicitation レスポンスパーサが MCP 仕様を解釈できない
- [openai/codex#11816](https://github.com/openai/codex/issues/11816) elicitation で hang する

対策:
- `codex mcp-server` は **MCP tool-call arguments を起動時 config より優先**するため、呼び出しごとに `cwd` / `approval-policy="never"` / `sandbox="workspace-write"` を渡すよう `user-rules.md` に明文化
- `sandbox_workspace_write.writable_roots = ["$HOME/ghq"]` を追加し、ghq 配下の sibling repo 参照・書き込みで escalation が発生しないよう整備
- `config.toml` は ERB テンプレート化し、public repo に絶対パス (`/Users/...`) を含めない構成に変更

## Test plan
- [ ] Claude Code を再起動し、`~/.mcp.json` と `~/.codex/config.toml` が新設定で反映されていることを確認
- [ ] `cat ~/.codex/config.toml` で `writable_roots = ["$HOME/ghq"]` 相当 (展開後は `/Users/.../ghq`) が書かれていることを確認
- [ ] Codex に別リポジトリ（例: ghq 配下）でのコード変更タスクを依頼し、承認プロンプトが出ないことを確認
- [ ] `~/.codex/sessions/.../rollout-*.jsonl` で `"approval_policy":"never"` が記録されていることを確認
