### PR TITLE
chore(mcp): drop git MCP from Claude allow list and user-rules

### DIFF
--- a/config/coding_agents/claude/settings.json
+++ b/config/coding_agents/claude/settings.json
@@ -22,7 +22,6 @@
       "WebFetch(*)",
       "WebSearch(*)",
       "mcp__yui__*",
-      "mcp__git__*",
       "mcp__slack__*",
       "mcp__playwright__*",
       "mcp__todoist__*",

--- a/config/coding_agents/user-rules.md
+++ b/config/coding_agents/user-rules.md
@@ -19,7 +19,6 @@ always respond in 日本語
 - **yui**: 会話履歴の圧縮版。会話開始時に必ず参照し、対話中は迷ったら記録
 - **notion**: 組織内のドメイン知識（広告ルール、medialakeやvertexlake等の社内リソース）の参照
 - **slack**: Slackのメッセージ検索、チャンネル閲覧、メッセージ送信、Canvas操作
-- **git**: Git操作（status、diff、commit等）
 - **playwright**: ブラウザ自動化・E2Eテスト
 - **todoist**: Todoistのタスク管理（作成・更新・完了・検索等）
 - **codex**: Codex へのタスク移譲（「Codex オフロード」セクション参照）


### PR DESCRIPTION
## Summary
- `Bash(git ...)` で git MCP と同等の操作が全てカバーできるため、MCP サーバとしての git は不要
- 有効にしておくと tool schema 分が毎プロンプトに乗って input トークンを消費するだけなので削除
- 実際の `~/.claude/settings.local.json` / `.dotfiles/.claude/settings.local.json` の `enabledMcpjsonServers` からも git を外し済み（別途ローカル編集、gitignored）

## Changes
- `config/coding_agents/claude/settings.json`: `permissions.allow` から `mcp__git__*` を削除
- `config/coding_agents/user-rules.md`: 「積極的にMCPを活用せよ」リストから `**git**` 行を削除

## Test plan
- [ ] Claude Code を再起動し、`mcp__git__*` ツールが提示されないことを確認
- [ ] `git status` / `git diff` / `git commit` 等が `Bash(*)` 許可下で問題なく動作することを確認
