### PR TITLE
feat(mcp): register context7 for Claude and Codex, tune Codex model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - `.cursor/hooks/state` はGit管理しない。認証情報・機密情報はコミットしない。リポジトリはpublicである
 - ターミナルのカラーテーマはダーク×ウォーム系が好み（ネイビー系は嫌い）
 - 個人の設定をプロジェクトの`.claude/rules/`に持ち込まない。グローバル設定（`~/.claude/CLAUDE.md`）で管理する
-- Context7はCursor/Claude Code両方ともplugin版を使う（MCP serverとしては管理しない）
+- Context7はClaude・Codex両方に MCP server として登録（`mcp.json.erb` / `codex/config.toml.erb`）。Claude は HTTP エンドポイント、Codex は stdio (`npx @upstash/context7-mcp`) を使用。Codex は Claude の MCP 接続を継承しないため、offload 時にライブラリドキュメントを参照させるには Codex 側にも登録が必要
 - 複数リポジトリの並列作業はtmuxセッション分離で行う（Ghosttyタブ複製ではなく）
 - tmuxのprefixはCtrl+Space（デフォルトのCtrl+Bはカーソル移動と競合するため変更済み）
 - Codexオフロードの移譲判断はrate limit依存ではなくタスク性質ベース。Claudeが特に優れる領域（設計・大規模リファクタ・MCP連携）以外は基本的にCodexに自動移譲する

--- a/config/coding_agents/codex/config.toml.erb
+++ b/config/coding_agents/codex/config.toml.erb
@@ -7,3 +7,7 @@ model_context_window = 1000000
 
 [sandbox_workspace_write]
 writable_roots = ["<%= ENV['HOME'] %>/ghq"]
+
+[mcp_servers.context7]
+command = "<%= ENV['HOME'] %>/.local/share/mise/shims/npx"
+args = ["-y", "@upstash/context7-mcp"]

--- a/config/coding_agents/codex/config.toml.erb
+++ b/config/coding_agents/codex/config.toml.erb
@@ -1,5 +1,9 @@
 approval_policy = "never"
 sandbox_mode = "workspace-write"
 
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+model_context_window = 1000000
+
 [sandbox_workspace_write]
 writable_roots = ["<%= ENV['HOME'] %>/ghq"]

--- a/config/coding_agents/mcp.json.erb
+++ b/config/coding_agents/mcp.json.erb
@@ -31,6 +31,10 @@
       "command": "<%= ENV['HOME'] %>/.local/share/mise/shims/npx",
       "args": ["-y", "supergateway", "--streamableHttp", "http://localhost:52981/mcp"]
     },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
     "codex": {
       "command": "codex",
       "args": [


### PR DESCRIPTION
## Summary
- Claude Code と Codex の両方に `context7` MCP server を登録
- Codex のモデルチューニング（gpt-5.4 / high reasoning / 1M context）を同梱

## Why
Codex は Claude とは別プロセスとして起動し、Claude の MCP 接続を**継承しない**。そのため、Codex offload 時にライブラリドキュメント参照（context7）が使えず、毎回 Claude が事前取得して `base-instructions` / `prompt` に埋める必要があった。両側に登録することで Codex 単体でも `@tanstack/query` 等の最新 doc を引ける。

## Changes
- `config/coding_agents/mcp.json.erb`
  ```json
  "context7": {
    "type": "http",
    "url": "https://mcp.context7.com/mcp"
  }
  ```
- `config/coding_agents/codex/config.toml.erb`
  ```toml
  [mcp_servers.context7]
  command = "$HOME/.local/share/mise/shims/npx"
  args = ["-y", "@upstash/context7-mcp"]
  ```
  - 併せてモデル設定を明示化 (`gpt-5.4` / reasoning=high / context=1M)
- `AGENTS.md`: 「context7 は MCP として管理しない」の古い記述を現状（両側登録）に合わせて更新

## 適用方法
PR merge 後、`./install.sh`（Mitamae）を実行して以下を再生成：
- `~/.mcp.json`（mcp.json.erb から）
- `~/.codex/config.toml`（codex/config.toml.erb から）

Claude Code / Codex を再起動すると context7 が有効になる。

## Test plan
- [x] `mcp.json.erb` が ERB 展開後に valid JSON
- [x] `codex/config.toml.erb` が ERB 展開後に valid TOML
- [ ] `./install.sh` 後、`~/.mcp.json` に context7 エントリが含まれること
- [ ] `~/.codex/config.toml` に `[mcp_servers.context7]` が含まれること
- [ ] Claude Code 再起動後、`mcp__context7__*` ツールが利用可能なこと
- [ ] Codex 起動後（`mcp__codex__codex` 呼び出し時）、Codex 側で context7 が使えること

## PR template check
`.github/pull_request_template.md` 不在・プロジェクトローカル `pr-template` skill 不在を確認済み。組み込みの `## Summary` / `## Test plan` 形式でよい。

## Related
- PR #10 (ルール簡素化) とはスコープが違うため別 PR。両方 merge 後に `user-rules.md` の context7 記述が実体と一致する状態になる
