### PR TITLE
chore(claude): disable 1M context for opus 4.7

### DIFF
--- a/config/coding_agents/claude/settings.json
+++ b/config/coding_agents/claude/settings.json
@@ -3,6 +3,7 @@
     "BASH_DEFAULT_TIMEOUT_MS": "30000",
     "BASH_MAX_TIMEOUT_MS": "120000",
     "CLAUDE_CODE_SUBAGENT_MODEL": "opus",
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
     "BASH_ENV": "",
     "ENV": "",
     "SHELL": "/bin/bash",
@@ -165,11 +166,12 @@
   },
   "outputStyle": "Structured",
   "language": "日本語",
+  "effortLevel": "high",
   "voice": {
     "enabled": true,
     "mode": "hold"
   },
   "skipAutoPermissionPrompt": true,
   "voiceEnabled": true,
-  "effortLevel": "high"
+  "theme": "dark-daltonized"
 }


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` to opt out of the auto-upgraded 1M context window for Opus 4.7 on Max/Team plans.
- Keeps the regular (smaller) context variant so token usage and cost stay predictable.

## Test plan
- [ ] Restart Claude Code and confirm the model indicator shows `claude-opus-4-7` (no `[1m]` suffix).
- [ ] Run `/model` picker and verify 1M variants are filtered out.