### PR TITLE
chore(mise): switch to curl install and manage config.toml in dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ $EDITOR cookbooks/:app_name/default.rb
 $EDITOR roles/$(uname)/default.rb
 ```
 
+### mise managed tools
+
+`cookbooks/mise/default.rb` installs mise via the official curl installer, deploys `config/mise/config.toml.erb` to `~/.config/mise/config.toml`, and runs `mise install` from that config.
+
+```mermaid
+flowchart TD
+    A[install mise via curl] --> B[Add mise shims to PATH]
+    B --> C[Install Python build packages on Ubuntu/Debian]
+    C --> D[Install tflint]
+    D --> E[Install kubectl and pnpm mise plugins]
+    E --> F[Deploy ~/.config/mise/config.toml from template]
+    F --> G[Run mise install for configured tools]
+```
+
 ## Coding Agents
 
 ### Configuration Structure

--- a/config/.zsh/lib/apps
+++ b/config/.zsh/lib/apps
@@ -18,7 +18,7 @@ export COMPOSE_DOCKER_CLI_BUILD=1
 
 # mise
 export MISE_ENV_FILE=.env
-eval "$(~/.cargo/bin/mise activate zsh)"
+eval "$(~/.local/bin/mise activate zsh)"
 
 # Google Cloud SDK Python setting (mise-managed python 3.12)
 if [ -x "$HOME/.local/share/mise/installs/python/3.12/bin/python3.12" ]; then

--- a/config/mise/config.toml.erb
+++ b/config/mise/config.toml.erb
@@ -1,0 +1,21 @@
+[tools]
+ghq = "latest"
+python = ["3.14", "3.12"]
+terraform = "latest"
+kubectl = "latest"
+node = "20"
+pnpm = "latest"
+flutter = "latest"
+ruby = "latest"
+go = "latest"
+
+[settings]
+experimental = true
+legacy_version_file_disable_tools = ["terraform", "packer"]
+
+[settings.python]
+compile = true
+
+[env]
+BASH_DEFAULT_TIMEOUT_MS = 1800000
+BASH_MAX_TIMEOUT_MS = 1800000

--- a/cookbooks/mise/default.rb
+++ b/cookbooks/mise/default.rb
@@ -1,74 +1,12 @@
-cargo 'mise'
-
-# Python
-python_minor_version = "3.11"
-python_version = "3.11.7"
-execute "install python with mise" do
-    command <<-EOF
-    mise install python@#{python_version}
-    mise use --global python@#{python_version}
-    EOF
-    not_if "mise ls | grep python"
+execute "install mise via curl" do
+    command 'curl -fsSL https://mise.run | sh'
+    not_if "test -x #{ENV['HOME']}/.local/bin/mise"
 end
 
 # miseで入れたものをPATHに追加
 unless ENV['PATH'].include?("#{ENV['HOME']}/.local/share/mise/shims")
     MItamae.logger.info("Prepending ~/.local/share/mise/shims to PATH during this execution")
     ENV['PATH'] = "#{ENV['HOME']}/.local/share/mise/shims:#{ENV['PATH']}"
-end
-
-# terraform
-terraform_version = "latest"
-execute "install terraform with mise" do
-    command <<-EOF
-        mise install terraform@#{terraform_version}
-        mise use --global terraform@#{terraform_version}
-    EOF
-    not_if "mise ls | grep terraform"
-end
-
-kubectl_version = "latest"
-execute "install kubectl with mise" do
-    command <<-EOF
-        mise plugin install kubectl https://github.com/asdf-community/asdf-kubectl.git
-        mise install kubectl@#{kubectl_version}
-        mise use --global kubectl@#{kubectl_version}
-    EOF
-    not_if "mise ls | grep kubectl"
-end
-
-# node
-node_version = "latest"
-execute "install node with mise" do
-    command <<-EOF
-        mise install node@#{node_version}
-        mise use --global node@#{node_version}
-    EOF
-    not_if "mise ls | grep node"
-end
-
-# pnpm
-execute "install mise pnpm plugin" do
-    command ""
-    not_if "mise plugin | grep pnpm"
-end
-pnpm_version = "latest"
-execute "install pnpm with mise" do
-    command <<-EOF
-        mise plugin install pnpm https://github.com/jonathanmorley/asdf-pnpm.git
-        mise install pnpm@#{pnpm_version}
-        mise use --global pnpm@#{pnpm_version}
-    EOF
-    not_if "mise ls | grep pnpm"
-end
-
-# go
-execute "install go with mise" do
-    command <<-EOF
-        mise install go@latest
-        mise use --global go@latest
-    EOF
-    not_if "mise ls | grep go"
 end
 
 # for python
@@ -102,11 +40,33 @@ else
     end
 end
 
-# flutter if darwin
-case node[:platform]
-when 'darwin'
-    execute "install flutter with mise" do
-        command "mise install flutter@latest"
-        not_if "mise ls | grep flutter"
-    end
+execute "install mise kubectl plugin" do
+    command "#{ENV['HOME']}/.local/bin/mise plugin install kubectl https://github.com/asdf-community/asdf-kubectl.git"
+    not_if "#{ENV['HOME']}/.local/bin/mise plugin | grep -q kubectl"
+end
+
+execute "install mise pnpm plugin" do
+    command "#{ENV['HOME']}/.local/bin/mise plugin install pnpm https://github.com/jonathanmorley/asdf-pnpm.git"
+    not_if "#{ENV['HOME']}/.local/bin/mise plugin | grep -q pnpm"
+end
+
+mise_config_erb = File.expand_path('../../config/mise/config.toml.erb', __dir__)
+
+directory "#{ENV['HOME']}/.config/mise" do
+    user node[:user]
+end
+
+execute "rm -f #{ENV['HOME']}/.config/mise/config.toml" do
+    only_if "test -L #{ENV['HOME']}/.config/mise/config.toml"
+end
+
+template "#{ENV['HOME']}/.config/mise/config.toml" do
+    source mise_config_erb
+    user node[:user]
+    mode '0644'
+end
+
+execute "mise install all tools from config" do
+    command "#{ENV['HOME']}/.local/bin/mise install"
+    user node[:user]
 end

--- a/cookbooks/mise/default.rb
+++ b/cookbooks/mise/default.rb
@@ -50,7 +50,7 @@ execute "install mise pnpm plugin" do
     not_if "#{ENV['HOME']}/.local/bin/mise plugin | grep -q pnpm"
 end
 
-mise_config_erb = File.expand_path('../../config/mise/config.toml.erb', __dir__)
+mise_config_erb = File.expand_path('../../config/mise/config.toml.erb', File.dirname(__FILE__))
 
 directory "#{ENV['HOME']}/.config/mise" do
     user node[:user]


### PR DESCRIPTION
## Summary

mise の install ルートを cargo から公式 curl installer に切り替え、`~/.config/mise/config.toml` を dotfiles で宣言的に管理するように整理する。古い `python_compile` flat 設定が新仕様で warning を出していたため、`[settings.python] compile` に併せて移行。

## Why

- mise 公式は cargo 経由 install を推奨外に変更（rustc 依存・コンパイル時間・install path 不一致）
- `cookbooks/mise/default.rb` で各 tool を `mise install/use --global` で個別 install していたが、`mise use --global` の結果が `~/.config/mise/config.toml` に書き出される一方、その config.toml が dotfiles 管理外で野良管理されていて二重管理状態だった
- `~/.config/mise/config.toml` の `[settings] python_compile = true` が新仕様で unknown field warning を出していた（新形式は `[settings.python] compile = true`）

## What changed

- `cookbooks/mise/default.rb`
  - `cargo 'mise'` を削除し `execute "install mise via curl"` に置換（idempotent: `test -x ~/.local/bin/mise` でガード）
  - 各 tool (python / terraform / node / pnpm / kubectl / go / flutter) の個別 `mise install` / `mise use --global` ブロックを削除し、config.toml の `[tools]` に集約
  - mise binary 呼び出しはすべて絶対パス `~/.local/bin/mise` で固定（PATH 上に古い cargo 版があっても新版が呼ばれる）
  - kubectl / pnpm の plugin 登録（asdf plugin）は core で扱われない可能性があるため保守的に保持
  - 末尾で `~/.config/mise/config.toml` を template で配置し、その後に `mise install` を 1 回実行
- `config/mise/config.toml.erb`（新規）
  - 既存の手動編集 config を等価移植
  - `python_compile = true` を `[settings.python] compile = true` 形式に修正
- `README.md`
  - mise 管理フローを mermaid 付きで追記（AGENTS.md のドキュメント更新ルール準拠）

## Provisioning order

```
1. install mise via curl
2. ~/.local/share/mise/shims を PATH に追加
3. ubuntu/debian: python ビルド依存 (build-essential 等)
4. tflint (darwin: package, linux: curl)
5. mise plugin install (kubectl, pnpm)
6. ~/.config/mise/config.toml を template で配置
7. mise install (config.toml の [tools] を一括 install)
```

## Test plan

- [ ] `cargo uninstall mise` で旧 cargo 版を削除
- [ ] `./install.sh` を実行して mitamae apply が通ることを確認
- [ ] `~/.local/bin/mise --version` で curl 版に切り替わっていることを確認
- [ ] `mise --version` 実行時に `python_compile` warning が出ないことを確認
- [ ] `mise ls` で `[tools]` の各 tool が install 済みであることを確認
- [ ] `~/.config/mise/config.toml` の内容が template と一致することを確認