### PR TITLE
feat(role): add lightweight devcontainer role

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ $EDITOR cookbooks/:app_name/default.rb
 $EDITOR roles/$(uname)/default.rb
 ```
 
+### Dev Container (lightweight role)
+
+`roles/devcontainer/` is a lightweight role intended for Dev Containers (e.g. the `@devcontainers/cli` workflow in [tyaba-env](https://github.com/Tyaba/tyaba-env)). It assumes:
+
+- devcontainer features already installed `git` / `gh` / `gcloud` / `mise` / `claude`
+- project `.mise.toml` installs language runtimes (`python` / `uv` / `node` / `pnpm`)
+
+It deploys only user-level dotfiles (`.claude/`, `.codex/`, `.cursor/`, `.mcp.json`, `.gitconfig`, zsh config) and the Codex CLI (needed by the `codex` MCP server in `~/.mcp.json`). Heavy cookbooks (emacs / docker / ghostty / redis / brew / GUI apps) and macOS-only setup are skipped.
+
+Run without sudo:
+
+```shell
+DOTFILES_ROLE=devcontainer ./install.sh
+```
+
+`install.sh` detects the env var and runs mitamae as the workspace user (no `sudo -E`), since this role only touches `$HOME`. `lib/recipe.rb` then routes to `roles/devcontainer/default.rb` instead of the platform default.
+
 ### mise managed tools
 
 `cookbooks/mise/default.rb` installs mise via the official curl installer, deploys `config/mise/config.toml.erb` to `~/.config/mise/config.toml`, and runs `mise install` from that config.

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,13 @@ set -ex
 
 bin/setup
 
+# DOTFILES_ROLE=devcontainer skips sudo: deploys only user-level
+# dotfiles + codex CLI (no apt / no system packages).
+if [ "${DOTFILES_ROLE:-}" = "devcontainer" ]; then
+  bin/mitamae local $@ lib/recipe.rb
+  exit
+fi
+
 case "$(uname)" in
   "Darwin")  bin/mitamae local $@ lib/recipe.rb ;;
   *) sudo -E bin/mitamae local $@ lib/recipe.rb ;;

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -17,4 +17,4 @@ when 'darwin'
   )
 end
 
-include_role node[:platform]
+include_role(ENV['DOTFILES_ROLE'] || node[:platform])

--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -1,0 +1,29 @@
+# Lightweight role for dev containers (Ubuntu/Debian base image).
+#
+# Assumptions:
+# - devcontainer features already installed git / gh / gcloud / mise / claude
+# - project .mise.toml installs language runtimes (python/uv, node/pnpm)
+# - install.sh runs as the workspace user (no sudo) when DOTFILES_ROLE=devcontainer
+#
+# Deploys user-level dotfiles (coding agents, MCP, gitconfig, zsh) and the
+# codex CLI which claude's MCP config depends on. Heavy cookbooks
+# (emacs / docker / ghostty / redis / brew / GUI apps) and macOS-only setup
+# are intentionally excluded.
+
+# mise shims must be on PATH so npm/uv calls below find mise-managed tools.
+# (Devcontainer features install mise but PATH propagation depends on the
+# shell context; ensure it explicitly here.)
+mise_shims = "#{ENV['HOME']}/.local/share/mise/shims"
+unless ENV['PATH'].include?(mise_shims)
+  MItamae.logger.info("Prepending #{mise_shims} to PATH for this run")
+  ENV['PATH'] = "#{mise_shims}:#{ENV['PATH']}"
+end
+
+include_role 'base'
+
+# Codex CLI is referenced by ~/.mcp.json (codex MCP server). Without it,
+# claude logs MCP startup errors on every launch.
+execute 'install codex cli' do
+  command 'npm install -g @openai/codex'
+  not_if 'which codex'
+end


### PR DESCRIPTION
## Why

`@devcontainers/cli` ベースで Dev Container を立ち上げて Claude Code を回す用途では、`roles/ubuntu/default.rb` のフルセット（emacs / docker / ghostty / redis / brew / GUI apps 等）は不要。devcontainer features 側で `claude` / `mise` / `git` / `gh` / `gcloud` がすでに入っているので、dotfiles 側がやるべきは **user-level の coding agent 設定の symlink + Codex CLI の install** だけ。

[tyaba-env](https://github.com/Tyaba/tyaba-env) の devcontainer template から `./install.sh` を呼ぶ際の軽量経路を提供する。

## 構成

### `roles/devcontainer/default.rb` (新規)

```ruby
mise_shims = "#{ENV['HOME']}/.local/share/mise/shims"
unless ENV['PATH'].include?(mise_shims)
  ENV['PATH'] = "#{mise_shims}:#{ENV['PATH']}"
end

include_role 'base'

execute 'install codex cli' do
  command 'npm install -g @openai/codex'
  not_if 'which codex'
end
```

- `include_role 'base'` で `.claude/` / `.cursor/` / `.codex/` / `.mcp.json` / `.gitconfig` / zsh config を deploy
- mise shims を PATH に明示的に prepend (`npm` を見つけるため)
- `codex` CLI は `~/.mcp.json` の `codex` MCP server が依存するので必須

### `lib/recipe.rb` (修正)

```diff
-include_role node[:platform]
+include_role(ENV['DOTFILES_ROLE'] || node[:platform])
```

`DOTFILES_ROLE` で role を override 可能に。未指定なら従来通り `node[:platform]`。

### `install.sh` (修正)

devcontainer role は `\$HOME` しか触らないので、Linux でも sudo を付けず workspace user (vscode) のまま mitamae を実行する。sudo の `secure_path` で mise shims が剥がれる問題も回避できる。

### `README.md` (追記)

Dev Container 用途のセクションを追加。

## 使い方

devcontainer の postCreateCommand から:

```bash
DOTFILES_ROLE=devcontainer ./install.sh
```

[Tyaba/tyaba-env#60](https://github.com/Tyaba/tyaba-env/pull/60) と組み合わせると、container 起動時に自動で:

1. devcontainer features で claude / gh / gcloud / mise が install される
2. mise install で .mise.toml の language runtime (python / uv / node / pnpm) が install される
3. `./install.sh` 経由でこのロールが走り、ホスト側 dotfiles の `.claude/CLAUDE.md` / `settings.json` / skills / hooks / MCP / `.codex/AGENTS.md` 等が symlink される
4. Codex CLI が npm install -g される (MCP の codex server が起動可能になる)

## 影響範囲

- 既存ユーザの `./install.sh` 実行: **挙動変わらず**（`DOTFILES_ROLE` 未指定なら従来通り）
- `lib/recipe.rb` の差分は env var の OR ガードを 1 行入れるだけ
- `install.sh` の差分は env var 判定の 1 ブロック追加のみ

## Test plan

- [x] `ruby -c roles/devcontainer/default.rb` / `lib/recipe.rb` syntax OK
- [x] `sh -n install.sh` syntax OK
- [x] 機密情報 (token / key / email) を一切含まないことを確認 (public repo 前提)
- [ ] (follow-up) 実機 (tyaba-env から生成した devcontainer) で `DOTFILES_ROLE=devcontainer ./install.sh` を流して
  - [ ] `~/.claude/settings.json` 等が symlink されること
  - [ ] `~/.mcp.json` が生成されること
  - [ ] `codex` CLI が install され `which codex` が通ること
  - [ ] container 内 `claude --dangerously-skip-permissions` の MCP startup が codex を含めて成功すること
- [ ] (follow-up) macOS で従来の `./install.sh` (DOTFILES_ROLE 未指定) が引き続き動くこと