### PR TITLE
fix(install): cd into script dir so relative paths work from any caller

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,13 @@
 
 set -ex
 
+# Resolve relative paths (bin/setup, bin/mitamae, lib/recipe.rb) against this
+# script's directory rather than the caller's cwd. Without this, calling
+# `$DOTFILES_DIR/install.sh` from elsewhere (e.g. a devcontainer
+# postCreateCommand running from /workspaces/<project>) fails with
+# `bin/setup: not found`.
+cd "$(dirname "$0")"
+
 bin/setup
 
 # DOTFILES_ROLE=devcontainer skips sudo: deploys only user-level


### PR DESCRIPTION
## Summary

`install.sh` を caller の cwd に依存しないよう修正する。`$DOTFILES_DIR/install.sh` のように外部から絶対パスで呼ばれた場合、`bin/setup` などの相対参照が caller の cwd を base に解決されてしまい、`bin/setup: not found` で失敗していた。

## 背景

Tyaba/tyaba-env の devcontainer post-create スクリプトが `env DOTFILES_ROLE=devcontainer "$DOTFILES_DIR/install.sh"` で本スクリプトを呼んだところ、コンテナの作業ディレクトリ (`/workspaces/<project>`) に `bin/setup` を探しに行って失敗した。再現ログ:

```
[post-create] step: install dotfiles (devcontainer role)
+ bin/setup
/home/vscode/dotfiles/install.sh: 5: bin/setup: not found
```

caller 側 (tyaba-env #64) でも `sh -c "cd $DOTFILES_DIR && ./install.sh"` で回避しているが、`install.sh` 自身が cwd 非依存になっているのが筋。

## 変更

```diff
 #!/bin/sh
 
 set -ex
 
+cd "$(dirname "$0")"
+
 bin/setup
```

(コメントで意図を残している。詳細は diff 参照。)

## 検証

- [x] tyaba-env #64 を merge する前提だが、ローカルで `cd /tmp && env DOTFILES_ROLE=devcontainer /Users/s17536/ghq/github.com/Tyaba/dotfiles/install.sh` を流して `bin/setup` が見つかることを確認
- [x] devcontainer 内で post-create が `bin/setup` → mitamae のダウンロードまで進むことを実機確認

## 既知の残課題 (別 PR)

devcontainer 内で mitamae のレシピを実行すると、`directory[/home/vscode/.cursor]` などの `directory` リソースが `sudo -H -u vscode -- mkdir -p ...` を試み、vscode が sudoers でないため失敗する。本 PR の cd 修正とは独立した別問題で、レシピ側で devcontainer 時に sudo を要求しないよう修正する PR を別途用意する。
