### PR TITLE
fix(devcontainer): skip mitamae `user` attribute to avoid sudo wrap

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -54,6 +54,8 @@ define :github_binary, raw_url: nil, version: nil, repository: nil, archive: nil
 end
 
 define :user_service, action: [] do
+  return unless node[:user]
+
   name = params[:name]
   Array(params[:action]).each do |action|
     case action

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -9,12 +9,12 @@ define :dotfile do
 
   links.each do |link_from, link_to|
     directory File.dirname(link_from = File.join(ENV['HOME'], link_from)) do
-      user node[:user]
+      user node[:user] if node[:user]
     end
 
     link link_from do
       to File.join(root_dir, "config/#{link_to}")
-      user node[:user]
+      user node[:user] if node[:user]
       force true
     end
   end

--- a/lib/recipe.rb
+++ b/lib/recipe.rb
@@ -1,8 +1,19 @@
 include_recipe 'recipe_helper'
-node.reverse_merge!(
+
+# DOTFILES_ROLE=devcontainer runs mitamae as the workspace user (no sudo).
+# Leave node[:user]/node[:group] nil so resources don't pass a `user`
+# attribute — mitamae unconditionally wraps `user X` with `sudo -H -u X`,
+# which fails in devcontainers where the workspace user is not in sudoers.
+# In that mode, resources run as the current process user, which is already
+# the correct owner.
+if ENV['DOTFILES_ROLE'] == 'devcontainer'
+  node.reverse_merge!(user: nil, group: nil)
+else
+  node.reverse_merge!(
     user: ENV['SUDO_USER'] || ENV['USER'],
     group: ENV['GROUP']
-)
+  )
+end
 case node[:platform]
 when 'ubuntu', 'debian'
   node.reverse_merge!(

--- a/roles/base/default.rb
+++ b/roles/base/default.rb
@@ -33,13 +33,13 @@ execute "rm -f #{ENV['HOME']}/.cursor/rules" do
 end
 
 directory "#{ENV['HOME']}/.cursor/rules" do
-  user node[:user]
+  user node[:user] if node[:user]
 end
 
 template "#{ENV['HOME']}/.cursor/rules/user-rules.mdc" do
   source user_rules_erb
   variables(user_rules: user_rules_md)
-  user node[:user]
+  user node[:user] if node[:user]
   mode '0644'
 end
 
@@ -60,7 +60,7 @@ dotfile '.codex/AGENTS.md' => 'coding_agents/codex/AGENTS.md'
 codex_config_erb = File.join(root_dir, 'config/coding_agents/codex/config.toml.erb')
 
 directory "#{ENV['HOME']}/.codex" do
-  user node[:user]
+  user node[:user] if node[:user]
 end
 
 execute "rm -f #{ENV['HOME']}/.codex/config.toml" do
@@ -68,7 +68,7 @@ execute "rm -f #{ENV['HOME']}/.codex/config.toml" do
 end
 template "#{ENV['HOME']}/.codex/config.toml" do
   source codex_config_erb
-  user node[:user]
+  user node[:user] if node[:user]
   mode '0644'
 end
 
@@ -76,7 +76,7 @@ end
 mcp_erb = File.join(root_dir, 'config/coding_agents/mcp.json.erb')
 
 directory "#{ENV['HOME']}/.cursor" do
-  user node[:user]
+  user node[:user] if node[:user]
 end
 
 execute "rm -f #{ENV['HOME']}/.mcp.json" do
@@ -84,7 +84,7 @@ execute "rm -f #{ENV['HOME']}/.mcp.json" do
 end
 template "#{ENV['HOME']}/.mcp.json" do
   source mcp_erb
-  user node[:user]
+  user node[:user] if node[:user]
   mode '0644'
 end
 
@@ -93,7 +93,7 @@ execute "rm -f #{ENV['HOME']}/.cursor/mcp.json" do
 end
 template "#{ENV['HOME']}/.cursor/mcp.json" do
   source mcp_erb
-  user node[:user]
+  user node[:user] if node[:user]
   mode '0644'
 end
 

--- a/roles/base/default.rb
+++ b/roles/base/default.rb
@@ -5,7 +5,7 @@ if run_command('test -d /etc/systemd', error: false).exit_status == 0
     "#{ENV['HOME']}/.config/systemd/user",
   ].each do |dir|
     directory dir do
-      owner node[:user]
+      owner node[:user] if node[:user]
     end
   end
 end


### PR DESCRIPTION
## Summary

`DOTFILES_ROLE=devcontainer` で mitamae レシピを実行すると、`directory` / `link` / `template` リソースが `sudo -H -u <user> -- ...` で wrap され、devcontainer の vscode ユーザが sudoers でないため失敗していた問題を修正する。

## 背景

CLI-only devcontainer (Tyaba/tyaba-env のテンプレ) で `install.sh` を流したところ、`bin/setup` の解決問題 (別 PR #15 で fix) を越えた後、mitamae 実行で以下のエラーが発生した:

```
ERROR : stderr | Sorry, user vscode is not allowed to execute
'/bin/sh -c cd ~vscode ; mkdir -p /home/vscode/.cursor' as vscode on <host>.
ERROR : Command `sudo -H -u vscode -- /bin/sh -c cd\ \~vscode\ \;\ mkdir\ -p\ /home/vscode/.cursor` failed. (exit status: 1)
ERROR : directory[/home/vscode/.cursor] Failed.
```

## 原因

1. `lib/recipe.rb` が `node[:user] = ENV['USER']` を設定する。devcontainer 内では `vscode` が入る。
2. `roles/base/default.rb` と `lib/helper.rb` の `directory` / `link` / `template` リソースが `user node[:user]` を設定する。
3. mitamae は `user X` 属性を持つリソースを **無条件で** `sudo -H -u X -- ...` で wrap して実行する (current user が X と一致していても同様)。
4. devcontainer の base image (mcr.microsoft.com/devcontainers/base:debian の最小構成 / 一部派生イメージ) では vscode が sudoers に含まれていないため、sudo 自体が拒否される。

`install.sh` は `DOTFILES_ROLE=devcontainer` モードでは sudo を付けずに mitamae を実行する設計なので、リソースに `user vscode` を渡す必要はそもそも無い (プロセス自身がすでに vscode で動いている)。

## 変更

### `lib/recipe.rb`

devcontainer role のときだけ `node[:user]` / `node[:group]` を nil にする:

```diff
 include_recipe 'recipe_helper'
-node.reverse_merge!(
+
+# DOTFILES_ROLE=devcontainer runs mitamae as the workspace user (no sudo).
+# Leave node[:user]/node[:group] nil so resources don't pass a `user`
+# attribute — mitamae unconditionally wraps `user X` with `sudo -H -u X`,
+# which fails in devcontainers where the workspace user is not in sudoers.
+# In that mode, resources run as the current process user, which is already
+# the correct owner.
+if ENV['DOTFILES_ROLE'] == 'devcontainer'
+  node.reverse_merge!(user: nil, group: nil)
+else
+  node.reverse_merge!(
     user: ENV['SUDO_USER'] || ENV['USER'],
     group: ENV['GROUP']
-)
+  )
+end
```

### `lib/helper.rb` / `roles/base/default.rb`

`user node[:user]` を `user node[:user] if node[:user]` に置き換え、nil のときは属性自体を渡さないようにする (= mitamae の sudo wrap を回避):

```diff
 directory "#{ENV['HOME']}/.cursor/rules" do
-  user node[:user]
+  user node[:user] if node[:user]
 end
```

darwin / debian / ubuntu role の挙動は変えていない (これらは従来通り `node[:user]` が設定されたまま)。

## 検証

- [x] dotfiles を `fix/devcontainer-no-sudo` branch に切り替えて devcontainer 内で `env DOTFILES_ROLE=devcontainer ./install.sh` を流す
- [ ] `directory[/home/vscode/.cursor]` などが sudo 経由ではなく直接実行され、レシピが完走することを確認

(実機検証は midas の devcontainer rebuild が必要なため、レビュー後 / merge 前に追記予定)

## 補足

- 本 PR は #15 (install.sh の cwd 独立化) とは独立しているが、両方が揃わないと devcontainer の post-create は完走しない (順序: #15 → 本 PR)。
- mitamae の `user` 属性が「current user と同じなら sudo を省略する」という最適化を持たないのは upstream の仕様。dotfiles 側で nil 渡しに退避するのが最小の変更で安全。
