### PR TITLE
fix(devcontainer): install codex via mise npm backend (no sudo)

### DIFF
--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -23,7 +23,12 @@ include_role 'base'
 
 # Codex CLI is referenced by ~/.mcp.json (codex MCP server). Without it,
 # claude logs MCP startup errors on every launch.
-execute 'install codex cli' do
-  command 'npm install -g @openai/codex'
-  not_if 'which codex'
+#
+# Install via mise's npm backend instead of `npm install -g`: the devcontainer
+# role runs without sudo, so the system-wide npm prefix (/usr/lib/node_modules)
+# is not writable. mise installs into ~/.local/share/mise/installs and
+# creates a shim under ~/.local/share/mise/shims (already on PATH).
+execute 'install codex cli (mise npm backend)' do
+  command "mise use -g 'npm:@openai/codex@latest'"
+  not_if 'command -v codex'
 end


### PR DESCRIPTION
## Summary

`DOTFILES_ROLE=devcontainer` 時の `npm install -g @openai/codex` が EACCES で失敗していた問題を mise の npm backend 経由 install に切替えて修正する。

Follow-up to #16 (mitamae sudo wrap 回避). #16 merge 後に Tyaba/tyaba-env の devcontainer を E2E rebuild した際に最後に残っていた失敗。

## 原因

`DOTFILES_ROLE=devcontainer` の install.sh は sudo を付けずに mitamae を走らせる設計 (vscode が sudoers でないコンテナ向け)。一方 devcontainer features が用意する npm の global prefix は system-wide (`/usr/lib/node_modules`) なので、vscode user では write できず EACCES。

```
npm error path /usr/lib/node_modules/@openai
npm error [Error: EACCES: permission denied, mkdir '/usr/lib/node_modules/@openai']
ERROR : Command `npm install -g @openai/codex` failed. (exit status: 243)
```

post-create が `|| true` で吸収するためコンテナ起動自体は成功するが、`~/.mcp.json` の codex MCP server が毎回起動エラーになる。

## 変更

`roles/devcontainer/default.rb` の codex install ステップを mise の npm backend へ切替:

- `mise use -g 'npm:@openai/codex@latest'`
- install 先: `~/.local/share/mise/installs/npm-@openai-codex/latest/`
- shim: `~/.local/share/mise/shims/codex`
- この role は冒頭で `~/.local/share/mise/shims` を PATH に prepend 済みなので、shim は同 mitamae run 内で `command -v codex` から見える

idempotency guard も `which codex` → `command -v codex` に変更 (POSIX shell builtin で `which` 非依存)。

## 代替案と却下理由

- `npm install -g --prefix=$HOME/.local @openai/codex`: 動くが `$HOME/.local/bin` を別途 PATH に通す必要があり、本 role はそこを設定していない
- `sudo npm install -g @openai/codex`: vscode は `(root) NOPASSWD` を持つので動くが、本 role の "no sudo" 設計から外れる
- mise の npm backend: 既存の PATH 設定を活かせ、user-local で sudo 不要、本 role の前提と整合

## Test plan

検証環境: Tyaba/tyaba-env v0.20.1 ベースの midas (`mcr.microsoft.com/devcontainers/base:ubuntu` / mise 2026.5.6 / devcontainer CLI 0.86.1)。本 PR の branch (`fix/devcontainer-codex-install-no-sudo`) を `~/dotfiles` で checkout し、`env DOTFILES_ROLE=devcontainer ./install.sh` を再走させて確認 (2026-05-12)。

- [x] mitamae の `execute[install codex cli (mise npm backend)]` が sudo 失敗なく完走 (`mise use -g 'npm:@openai/codex@latest'` 成功)
- [x] `mise ls --installed` で `npm:@openai/codex 0.130.0 ~/.config/mise/config.toml latest` を確認
- [x] `~/.config/mise/config.toml` に `"npm:@openai/codex" = "latest"` が pin
- [x] `command -v codex` が `/home/vscode/.local/share/mise/shims/codex` を返す (devcontainer exec 経由 / `remoteEnv.PATH` が効いた環境で)
- [x] `codex --version` → `codex-cli 0.130.0`
- [x] `~/.mcp.json` の `codex` エントリが `codex mcp-server -c approval_policy=...` を参照しており、`timeout 3 codex mcp-server` 起動時に startup error なし (exit 0 まで stderr 出力なし)

### 補足

- 通常 `docker exec -u vscode bash -lc` で入った場合は `remoteEnv` がスキップされ PATH に shims が乗らないため `codex` が `command not found` になる点に注意。VS Code / `devcontainer exec` / claude 経由 (post-create.sh が走る経路) では `remoteEnv.PATH` が効くので問題なし。

