### PR TITLE
feat(coding_agents): sync ~/.mcp.json into Claude Code user scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ config/
     ├── hooks/              # Shared hooks
     ├── skills/             # Shared skills
     ├── mcp.json.erb        # MCP server definitions (ERB template)
+    ├── sync-claude-user-mcp.sh
     └── user-rules.md       # Shared user rules (Claude Code / Cursor)
 ```
 
@@ -95,6 +96,22 @@ config/
 | `config/coding_agents/skills/` | `~/.claude/skills/`, `~/.cursor/skills/` |
 | `config/coding_agents/mcp.json.erb` | `~/.mcp.json`, `~/.cursor/mcp.json` |
 | `config/coding_agents/codex/AGENTS.md` | `~/.codex/AGENTS.md` |
+
+After rendering `~/.mcp.json`, `roles/base/default.rb` runs
+`config/coding_agents/sync-claude-user-mcp.sh`. The script reads the rendered MCP
+definitions and registers them with `claude mcp add --scope user`, so Claude Code
+also sees them in devcontainers where `/workspaces/<name>` is outside `$HOME`.
+
+```mermaid
+flowchart TD
+    A[config/coding_agents/mcp.json.erb] --> B[Render ~/.mcp.json]
+    A --> C[Render ~/.cursor/mcp.json]
+    B --> D[sync-claude-user-mcp.sh]
+    D --> E[claude mcp add --scope user]
+    E --> F[~/.claude.json top-level mcpServers]
+    F --> G[Claude Code reads MCP servers independent of cwd]
+    C --> H[Cursor and cwd-ancestor clients]
+```
 
 ### Codex Offload (via MCP server)
 

--- a/config/coding_agents/sync-claude-user-mcp.sh
+++ b/config/coding_agents/sync-claude-user-mcp.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Claude Code discovers project-scoped .mcp.json files by walking cwd ancestors.
+# On host machines, projects usually live under $HOME, so ~/.mcp.json is found.
+# In devcontainers, projects live under /workspaces/<name>, outside $HOME.
+# That ancestor walk stops before /home/vscode, so ~/.mcp.json is ignored there.
+# User-scoped MCP entries are stored in ~/.claude.json instead.
+# Claude Code reads that user scope independently from cwd.
+# This sync keeps config/coding_agents/mcp.json.erb as the single source of truth.
+
+MCP_JSON="${MCP_JSON:-$HOME/.mcp.json}"
+
+log() {
+  echo "[sync-claude-user-mcp] $*" >&2
+}
+
+if ! command -v claude >/dev/null 2>&1; then
+  log "warning: claude command not found; skipping"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  log "warning: jq command not found; skipping"
+  exit 0
+fi
+
+if [ ! -f "$MCP_JSON" ]; then
+  log "warning: $MCP_JSON not found; skipping"
+  exit 0
+fi
+
+while IFS= read -r row; do
+  decode() {
+    echo "$row" | base64 --decode | jq -r "$1"
+  }
+
+  name=$(decode '.key')
+  type=$(decode '.value.type // "stdio"')
+
+  claude mcp remove --scope user "$name" >/dev/null 2>&1 || true
+
+  case "$type" in
+    http|sse)
+      url=$(decode '.value.url')
+      claude mcp add --scope user --transport "$type" "$name" "$url" >/dev/null
+      ;;
+    stdio)
+      cmd=$(decode '.value.command')
+      args=()
+      while IFS= read -r a; do
+        args+=("$a")
+      done < <(echo "$row" | base64 --decode | jq -r '.value.args[]?')
+
+      if [ ${#args[@]} -gt 0 ]; then
+        claude mcp add --scope user "$name" -- "$cmd" "${args[@]}" >/dev/null
+      else
+        claude mcp add --scope user "$name" -- "$cmd" >/dev/null
+      fi
+      ;;
+    *)
+      log "unknown transport for $name: $type"
+      continue
+      ;;
+  esac
+
+  log "synced $name ($type)"
+done < <(jq -r '.mcpServers | to_entries[] | @base64' "$MCP_JSON")

--- a/roles/base/default.rb
+++ b/roles/base/default.rb
@@ -88,6 +88,13 @@ template "#{ENV['HOME']}/.mcp.json" do
   mode '0644'
 end
 
+sync_user_mcp = File.join(root_dir, 'config/coding_agents/sync-claude-user-mcp.sh')
+
+execute 'sync ~/.mcp.json into claude user scope' do
+  command "bash #{sync_user_mcp}"
+  user node[:user] if node[:user]
+end
+
 execute "rm -f #{ENV['HOME']}/.cursor/mcp.json" do
   only_if "test -L #{ENV['HOME']}/.cursor/mcp.json"
 end


### PR DESCRIPTION
## Summary

Claude Code を devcontainer 内で起動した時に MCP サーバー (yui / slack / notion / 等) が一切認識されなくなる問題への恒久対応。`config/coding_agents/mcp.json.erb` を **唯一の source of truth** にしつつ、host / container の両方で同じ MCP セットが見えるようにする。

## 背景

Claude Code は project local `.mcp.json` を cwd の祖先方向に向かって探索する仕様。

- **host** では project が `$HOME/ghq/...` 配下にあるため、祖先探索の途中で `$HOME/.mcp.json` が拾われる → MCP が見える ✅
- **devcontainer** では project が `/workspaces/<name>` 配下、`$HOME=/home/vscode` は **祖先関係に無い**。`/workspaces/` → `/` で打ち切られるため `~/.mcp.json` が読まれない → MCP が一切見えない ❌

実機検証 (Claude Code 2.1.139):

```bash
# container 内
$ cd /workspaces/ganyu && claude mcp list
context7: npx -y @upstash/context7-mcp - ✓ Connected   # project local .mcp.json から
# (yui / slack / notion / todoist / 等は表示されない)

$ cd ~ && claude mcp list
git: ... yui: ... slack: ...                            # ~/.mcp.json から全部見える
```

## 解決方針

`~/.mcp.json` は残しつつ (Cursor 等 cwd-ancestor 派の他クライアント用)、Claude Code 向けには `claude mcp add --scope user` で `~/.claude.json` の top-level `mcpServers` にも同期する。user scope は cwd に依存せず常時読まれる (実機確認済み)。

## 変更内容

### 新規 `config/coding_agents/sync-claude-user-mcp.sh`

- `$HOME/.mcp.json` を読んで各 entry を `claude mcp add --scope user` で登録
- HTTP / SSE / stdio すべて対応
- 冪等性: 先に `claude mcp remove --scope user` を叩いてから add (erb の編集を毎回反映)
- `claude` / `jq` / MCP JSON が無ければ warn して exit 0 (mitamae の他ステップを止めない)
- bash 3.2 (macOS 標準) 対応: `readarray` / `mapfile` 不使用、process substitution + `while read` + `args=()` のみ

### `roles/base/default.rb`

- 既存 `~/.mcp.json` template render の直後に sync スクリプトを execute する `execute` resource を追加
- `~/.cursor/mcp.json` template は変更なし

### `README.md`

- ファイル構造に新スクリプト追記
- mermaid で `mcp.json.erb` → `~/.mcp.json` + `~/.cursor/mcp.json` + Claude user scope の同期フロー図を追加

## 検証

### Host (Darwin)

```bash
$ bash config/coding_agents/sync-claude-user-mcp.sh
[sync-claude-user-mcp] synced git (stdio)
[sync-claude-user-mcp] synced playwright (stdio)
[sync-claude-user-mcp] synced notion (http)
[sync-claude-user-mcp] synced slack (http)
[sync-claude-user-mcp] synced todoist (http)
[sync-claude-user-mcp] synced yui (stdio)
[sync-claude-user-mcp] synced context7 (http)
[sync-claude-user-mcp] synced codex (stdio)

$ jq '.mcpServers | keys' ~/.claude.json
["codex", "context7", "git", "notion", "playwright", "slack", "todoist", "yui"]
```

### Devcontainer (Ubuntu, tepein/ganyu)

```bash
$ devcontainer exec --workspace-folder . bash -c 'cd /workspaces/ganyu && claude mcp list 2>&1 | grep -vE "claude.ai|^$|Checking"'
git: ... ✗ Failed to connect           # uvx path 問題 (follow-up)
playwright: ... ✓ Connected
notion: ... ! Needs authentication
slack: ... ✗ Failed to connect          # OAuth 必要 (follow-up)
todoist: ... ! Needs authentication
yui: ... ✗ Failed to connect            # host.docker.internal 必要 (follow-up)
context7: ... ✓ Connected
codex: ... ✓ Connected
```

**8 件全て user scope に登録され、cwd が `/workspaces/ganyu` でも認識される** ようになった (cwd-ancestor 問題が解消)。接続失敗の 3 件 (yui / git / slack) は本 PR の範囲外で、別 follow-up issue で対応:

- **yui**: container から `localhost:52981` 不通 → `host.docker.internal:52981` への切替、もしくは container 内 yui-proxy 起動
- **git** (`mcp-server-git`): container の `~/.local/bin/uvx` 不在 → mise shims `/home/vscode/.local/share/mise/shims/uvx` を使うか mcp.json.erb で `PATH` 解決を改善
- **slack** (HTTP OAuth): container 内で `/login` 相当の OAuth flow が必要

## Test plan

- [x] `bash -n config/coding_agents/sync-claude-user-mcp.sh` syntax 確認
- [x] `ruby -c roles/base/default.rb` syntax 確認
- [x] host で sync 実行 → `jq '.mcpServers | keys' ~/.claude.json` で 8 件
- [x] devcontainer 内 (`tepein/ganyu`) で sync 実行 → `claude mcp list` で 8 件 (cwd は `/workspaces/ganyu`)
- [ ] (merge 後) host で `./install.sh` 流して mitamae 経由でも動くこと
- [ ] (merge 後) devcontainer rebuild → post-create.sh 経由で自動同期されること

## Follow-ups

- yui MCP container 経由問題 (`host.docker.internal:52981` か yui-proxy.service)
- git MCP の uvx path 問題
- slack MCP の container OAuth
