### PR TITLE
fix(mcp): resolve uvx via mise shims for git mcp in devcontainer

### DIFF
--- a/config/coding_agents/mcp.json.erb
+++ b/config/coding_agents/mcp.json.erb
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "git": {
-      "command": "<%= ENV['HOME'] %>/.local/bin/uvx",
+      "command": "<%= ENV['HOME'] %>/<%= ENV['DOTFILES_ROLE'] == 'devcontainer' ? '.local/share/mise/shims/uvx' : '.local/bin/uvx' %>",
       "args": ["mcp-server-git"]
     },
     "playwright": {


### PR DESCRIPTION
## Summary
- devcontainer 内で `claude mcp list` が git エントリを `Failed to connect` と表示する問題を修正
- ERB で `DOTFILES_ROLE` を条件分岐し、devcontainer のときだけ mise shim path を使う
- host (DOTFILES_ROLE 未設定) は従来通り `~/.local/bin/uvx` を維持

> Note: 当初 base は `feat/claude-user-scope-mcp-sync` (PR #18) を想定していたが、既に main へマージ済みのため base を `main` に変更。

## 背景
`config/coding_agents/mcp.json.erb` の git エントリは `command = "$HOME/.local/bin/uvx"` を使っていた。これは host で `uv` を `~/.local/bin/uvx` にインストールした場合は動くが、devcontainer ではそのパスにバイナリが存在しない。container は mise feature 経由で `uv` を入れているため、真の shim path は `~/.local/share/mise/shims/uvx`。

実機の devcontainer で `claude mcp list` を実行した際、git エントリのみ `✗ Failed to connect` となっていた。playwright / yui エントリは既に `$HOME/.local/share/mise/shims/npx` を使っており、container でも正常接続していた。

## 修正
`config/coding_agents/mcp.json.erb` の git エントリの `command` を ERB の三項演算子で切り替え：

```erb
"command": "<%= ENV['HOME'] %>/<%= ENV['DOTFILES_ROLE'] == 'devcontainer' ? '.local/share/mise/shims/uvx' : '.local/bin/uvx' %>"
```

`lib/recipe.rb` で既に同パターンの `DOTFILES_ROLE` 判別が使われている前例に揃えた。

## 検証
両モードで ERB を展開して `jq '.mcpServers.git'` で確認：

host (DOTFILES_ROLE 未設定):
```json
{
  "command": "/Users/s17536/.local/bin/uvx",
  "args": [
    "mcp-server-git"
  ]
}
```

devcontainer (DOTFILES_ROLE=devcontainer):
```json
{
  "command": "/Users/s17536/.local/share/mise/shims/uvx",
  "args": [
    "mcp-server-git"
  ]
}
```

JSON valid であることも `jq` パース成功で確認済み。

## host 影響
なし。`DOTFILES_ROLE` 未設定時は従来の `~/.local/bin/uvx` がそのまま使われる。
