### PR TITLE
fix(mcp): point yui to host.docker.internal in devcontainer

### DIFF
--- a/config/coding_agents/mcp.json.erb
+++ b/config/coding_agents/mcp.json.erb
@@ -29,7 +29,8 @@
     },
     "yui": {
       "command": "<%= ENV['HOME'] %>/.local/share/mise/shims/npx",
-      "args": ["-y", "supergateway", "--streamableHttp", "http://localhost:52981/mcp"]
+<%- yui_host = ENV['DOTFILES_ROLE'] == 'devcontainer' ? 'host.docker.internal' : 'localhost' -%>
+      "args": ["-y", "supergateway", "--streamableHttp", "http://<%= yui_host %>:52981/mcp"]
     },
     "context7": {
       "type": "http",


### PR DESCRIPTION
## Summary

devcontainer 内から yui MCP に到達できない問題を `config/coding_agents/mcp.json.erb` の ERB 条件分岐で修正。host (macOS / Linux) の挙動は完全に従来通り。

## 背景

`yui` MCP は host で `localhost:52981` を listen する yui-proxy (supergateway streamableHttp) 経由でアクセスする。

- **host**: `http://localhost:52981/mcp` で直接 yui-proxy に届く ✅
- **devcontainer**: container 内の `localhost` は container 自身。host の yui-proxy:52981 には届かない ❌

実機で `claude mcp list` が `yui: ✗ Failed to connect` を返していた。

## 修正

`mcp.json.erb` 内で `ENV['DOTFILES_ROLE']` を見て URL を切り替え。`lib/recipe.rb` は `DOTFILES_ROLE=devcontainer` で devcontainer モードを判別する既存の前例があるので、同じ discriminator を使う。

- devcontainer: `http://host.docker.internal:52981/mcp`
- それ以外 (host): `http://localhost:52981/mcp`

## 検証

\`\`\`bash
# host モード
$ ruby -e "require 'erb'; puts ERB.new(File.read('config/coding_agents/mcp.json.erb'), trim_mode: '-').result" | jq '.mcpServers.yui'
{
  \"command\": \"/Users/s17536/.local/share/mise/shims/npx\",
  \"args\": [\"-y\", \"supergateway\", \"--streamableHttp\", \"http://localhost:52981/mcp\"]
}

# devcontainer モード
$ DOTFILES_ROLE=devcontainer ruby -e "..." | jq '.mcpServers.yui'
{
  \"command\": \"/Users/s17536/.local/share/mise/shims/npx\",
  \"args\": [\"-y\", \"supergateway\", \"--streamableHttp\", \"http://host.docker.internal:52981/mcp\"]
}
\`\`\`

## Follow-up

- Linux Docker host で `host.docker.internal` を解決させるには devcontainer.json に `runArgs: ["--add-host=host.docker.internal:host-gateway"]` を入れる必要がある。tyaba-env 側の devcontainer template に同等指示を出す issue/PR は別途。
- macOS Docker Desktop は標準で `host.docker.internal` を解決する。

## Note

PR #18 (`feat/claude-user-scope-mcp-sync`) は既に main に merge 済みのため base は `main` を指定しました。