### PR TITLE
docs(mcp): document slack OAuth flow for devcontainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,47 @@ codex login          # Authenticate with ChatGPT Enterprise (one-time)
 
 **Constraints:**
 - Requires local OAuth authentication (browser flow) -- not available in CI/headless environments
+
+### Slack MCP OAuth in devcontainers
+
+The `slack` entry in `config/coding_agents/mcp.json.erb` is an HTTP-transport MCP
+server backed by Slack's hosted endpoint (`https://mcp.slack.com/mcp`) and
+authenticated via OAuth 2.0 (PKCE) with `callbackPort: 3118`. Claude Code
+performs the OAuth flow on first use and persists the resulting tokens
+client-side -- they are **not** part of `~/.mcp.json` or the rendered
+`mcpServers` config.
+
+Because Claude Code state inside a devcontainer lives in a separate named
+volume (`claude-code-config-${devcontainerId}`) from the host, the tokens
+obtained on the host are **not** visible to Claude Code running inside the
+container. As a result, `claude mcp list` inside the container will show:
+
+```
+slack  ✗ Failed to connect
+```
+
+until the OAuth flow is completed once from inside the container.
+
+#### Recommended workflow
+
+1. Start the devcontainer and run `claude` once.
+2. When `slack` is reported as unauthenticated, trigger the OAuth flow from
+   the Claude Code UI (e.g. `/login slack` or by invoking any `mcp__slack__*`
+   tool). Claude Code will open a browser on the host that posts the
+   authorization code back to `http://localhost:3118/...`.
+3. For the callback to reach the container, ensure
+   `forwardPorts: [3118]` is set in the project's `.devcontainer/devcontainer.json`.
+   This is configured at the [tyaba-env](https://github.com/Tyaba/tyaba-env)
+   template level, not here.
+4. Subsequent container starts reuse the saved tokens as long as the
+   `claude-code-config-*` named volume is preserved.
+
+#### Why not bind-mount the host tokens?
+
+Claude Code stores OAuth credentials in user-scoped state (under `~/.claude/`
+and `~/.claude.json`-adjacent locations) that also contains many other
+secrets unrelated to Slack. Bind-mounting these into the container would
+broaden the secret surface for every running container and is therefore not
+done by this dotfiles repo. A per-server token export/import workflow would
+be cleaner but is not currently provided by Claude Code; for now, a one-time
+in-container OAuth flow is the recommended path.


### PR DESCRIPTION
## Summary

- Documents the Slack MCP OAuth flow when running Claude Code inside a devcontainer.
- No code change -- README-only.

## Background

`config/coding_agents/mcp.json.erb` registers `slack` as an HTTP-transport MCP
server backed by `https://mcp.slack.com/mcp`, authenticated via OAuth 2.0
(PKCE) with `callbackPort: 3118`.

On the host, Claude Code performs the OAuth flow once and persists the
tokens client-side; subsequent runs reuse them transparently.

Inside a devcontainer, Claude Code state lives in a separate named volume
(`claude-code-config-${devcontainerId}`), isolated from the host. So the
tokens obtained on the host are not visible to the in-container instance,
and `claude mcp list` shows `slack` as `Failed to connect`.

## Investigation

- `~/.claude.json` `.mcpServers.slack` only stores `{ type, url }` -- no
  token fields. OAuth tokens are stored elsewhere in Claude Code's
  user-scoped state, not in any file deployed by this dotfiles repo.
- The dotfiles-side sync (`sync-claude-user-mcp.sh`) only registers
  server definitions via `claude mcp add --scope user`; it does not (and
  cannot) propagate OAuth tokens.
- Therefore, the OAuth flow must be re-run from inside the container at
  least once. Captured tokens persist across container restarts as long
  as the `claude-code-config-*` named volume is preserved.

## Adopted approach (option A)

Add a `Slack MCP OAuth in devcontainers` section to `README.md` covering:

- Why the in-container instance shows `Failed to connect`.
- The one-time `/login slack` (or first `mcp__slack__*` call) flow.
- Dependence on `forwardPorts: [3118]` in the project's
  `.devcontainer/devcontainer.json` so the OAuth callback at
  `http://localhost:3118` reaches the container.
- Rationale for not bind-mounting host tokens.

## Rejected approaches

- **Bind-mount host OAuth state into the container.** Claude Code stores
  Slack tokens alongside many unrelated secrets in user-scoped state.
  Bind-mounting would broaden secret exposure for every running
  container; rejected on security grounds.
- **Implement a Slack-token-only export/import.** Claude Code does not
  expose a stable per-server token export interface today; deferred.

## Follow-ups (out of scope for this PR)

- [tyaba-env] Add `"forwardPorts": [3118]` to the devcontainer template's
  `devcontainer.json.jinja` so generated devcontainers can receive the
  OAuth callback on port 3118.

## Test plan

- [ ] `git diff main...fix/slack-container-oauth -- README.md` shows only the new section.
- [ ] Render the README locally (e.g. on GitHub PR preview) and confirm formatting.

Note: original task description targeted base `feat/claude-user-scope-mcp-sync` (PR #18), but that branch was already merged into `main` and deleted on the remote, so `main` is used as the base here.
