### PR TITLE
fix(devcontainer): persist ~/.claude.json into ~/.claude/ volume

### DIFF
--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -42,7 +42,8 @@ execute 'persist ~/.claude.json into ~/.claude/ volume' do
     if [ -f "$LINK" ] && [ ! -L "$LINK" ]; then
       if [ -e "$TARGET" ] && [ ! -L "$TARGET" ]; then
         # Volume already has its own .claude.json — prefer it, archive host copy.
-        mv "$LINK" "$LINK.pre-link.bak"
+        # Timestamp the backup so repeated rebuilds don't clobber prior archives.
+        mv "$LINK" "$LINK.pre-link.bak.$(date +%s)"
       else
         mv "$LINK" "$TARGET"
       fi

--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -19,6 +19,52 @@ unless ENV['PATH'].include?(mise_shims)
   ENV['PATH'] = "#{mise_shims}:#{ENV['PATH']}"
 end
 
+# Persist ~/.claude.json across container rebuilds.
+#
+# devcontainer.json mounts ~/.claude/ as a named volume, but ~/.claude.json
+# is a regular file outside that mount. On rebuild, the file is recreated
+# empty and Claude Code re-prompts for onboarding even though credentials
+# (in ~/.claude/.credentials.json) are preserved.
+#
+# Symlink ~/.claude.json into the persistent volume so onboarding flags,
+# mcpServers config, and oauthAccount survive container recreation.
+claude_link   = "#{ENV['HOME']}/.claude.json"
+claude_target = "#{ENV['HOME']}/.claude/.claude.json"
+
+execute 'persist ~/.claude.json into ~/.claude/ volume' do
+  command <<~SH
+    set -eu
+    LINK="#{claude_link}"
+    TARGET="#{claude_target}"
+
+    # Case 1: $LINK is a regular file (not yet symlinked). Migrate its
+    # contents into the volume, archiving any volume-side file conflict.
+    if [ -f "$LINK" ] && [ ! -L "$LINK" ]; then
+      if [ -e "$TARGET" ] && [ ! -L "$TARGET" ]; then
+        # Volume already has its own .claude.json — prefer it, archive host copy.
+        mv "$LINK" "$LINK.pre-link.bak"
+      else
+        mv "$LINK" "$TARGET"
+      fi
+    fi
+
+    # Case 2: $TARGET still does not exist (fresh volume). Touch an empty file.
+    [ -e "$TARGET" ] || : > "$TARGET"
+
+    # Case 3: Ensure $LINK is a symlink pointing to $TARGET.
+    if [ -L "$LINK" ]; then
+      current="$(readlink "$LINK")"
+      if [ "$current" != "$TARGET" ]; then
+        rm "$LINK"
+        ln -s "$TARGET" "$LINK"
+      fi
+    elif [ ! -e "$LINK" ]; then
+      ln -s "$TARGET" "$LINK"
+    fi
+  SH
+  user node[:user] if node[:user]
+end
+
 include_role 'base'
 
 # Codex CLI is referenced by ~/.mcp.json (codex MCP server). Without it,


### PR DESCRIPTION
## Summary

- devcontainer 環境で `~/.claude.json` を `~/.claude/` 内に symlink して named volume に永続化する
- リビルド後も `hasCompletedOnboarding` / `mcpServers` / `oauthAccount` が保持され、`claude login` の再要求を防ぐ

## Why

`devcontainer.json` は `~/.claude/` ディレクトリを named volume としてマウントしているが、`~/.claude.json` 自体は**ディレクトリ外の単なるファイル**で永続化対象外。リビルドのたびに空ファイルが作り直され、`.credentials.json`(volume 内) は残っていても onboarding flag が消えて `claude login` が再表示される問題があった。

`roles/devcontainer/default.rb` に `~/.claude.json` → `~/.claude/.claude.json` の symlink を作成する execute block を追加。3 ケース対応:

1. 既存ファイルがある場合 → volume 側へ移行（衝突時は `.pre-link.bak` に退避）
2. fresh volume の場合 → 空ファイルを touch
3. symlink が正しい向きかを冪等に保証

`include_role 'base'` の前に挿入することで、後続の `sync-claude-user-mcp.sh`（mcpServers を `~/.claude.json` に書き込む）が symlink 越しに volume へ書き込めるようにしている。

## Test plan

- [x] `ruby -c roles/devcontainer/default.rb` 構文チェック通過
- [ ] ganyu の devcontainer をリビルドし、`claude` 起動時に login プロンプトが出ないことを確認
- [ ] `ls -la ~/.claude.json` で `-> /home/vscode/.claude/.claude.json` の symlink になっていることを確認
- [ ] `~/.mcp.json` に新規 MCP を追加 → `claude` 起動で `~/.claude/.claude.json` に反映されることを確認