### PR TITLE
feat(devcontainer): install claude-code via mise instead of feature

### DIFF
--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -79,3 +79,13 @@ execute 'install codex cli (mise npm backend)' do
   command "mise use -g 'npm:@openai/codex@latest'"
   not_if 'command -v codex'
 end
+
+# Install Claude Code CLI via mise instead of relying on the devcontainer feature.
+#
+# The devcontainer feature installs as root into /usr/lib/node_modules, so the
+# vscode user cannot self-update. mise installs under ~/.local/share/mise so
+# `claude` updates land in a vscode-writable path.
+execute 'install claude code cli (mise npm backend)' do
+  command "mise use -g 'npm:@anthropic-ai/claude-code@latest'"
+  not_if 'mise which claude >/dev/null 2>&1'
+end


### PR DESCRIPTION
## Summary

- `claude` CLI を devcontainer feature ではなく mise npm backend で導入する execute ブロックを追加
- 既存の `codex` の install パターンに合わせて整合性を担保
- `~/.local/share/mise/installs/` 配下に入るので vscode ユーザの auto-update が通る

## Why

`ghcr.io/anthropics/devcontainer-features/claude-code:1.0` は claude を root 所有で `/usr/lib/node_modules/@anthropic-ai/claude-code/` に入れる。consuming プロジェクトの devcontainer 内では vscode ユーザで claude を起動するが、書き込み権限がないため起動毎に「Auto-update failed」が表示される。

実機での確認結果（ganyu container 内）:

```
/usr/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe
owner=root mode=755
```

恒久対策として、すでに `codex` で採用している mise の npm backend に揃えると `~/.local/share/mise/installs/` 配下（vscode 所有）に入り、auto-update が機能する。

tyaba-env 側で feature を削除する PR を並行で出している。両方マージ後、consuming プロジェクト（ganyu 等）に copier update をかけて取り込む流れ。

## Implementation notes

- `not_if` には `command -v claude` ではなく `mise which claude` を使用。理由: 旧 feature が残ったプロジェクトでは `/usr/bin/claude` が存在し `command -v` で skip されてしまうが、`mise which` は mise 管理下のみ true を返すので feature 経由ではちゃんと install が走る

## Test plan

- [x] `ruby -c roles/devcontainer/default.rb` 構文チェック通過
- [ ] ganyu に copier update + rebuild 後、`mise which claude` が `~/.local/share/mise/...` を指すこと
- [ ] `claude` 起動時に Auto-update failed の警告が消えること
- [ ] auto-update 動作確認（バージョンが古いタイミングがあれば実機で）

## Related

- tyaba-env: feat/drop-claude-code-feature（並行 PR）