### PR TITLE
fix(hooks): skip paplay when binary is missing (e.g. devcontainer)

### DIFF
--- a/config/coding_agents/claude/settings.json.erb
+++ b/config/coding_agents/claude/settings.json.erb
@@ -117,7 +117,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PROJECT=$(basename \"$PWD\"); if [ \"$(uname)\" = \"Darwin\" ]; then osascript -e \"display notification \\\"$PROJECT: タスク完了\\\" with title \\\"Claude Code\\\" sound name \\\"Submarine\\\"\"; else paplay /usr/share/sounds/freedesktop/stereo/message.oga; fi"
+            "command": "PROJECT=$(basename \"$PWD\"); if [ \"$(uname)\" = \"Darwin\" ]; then osascript -e \"display notification \\\"$PROJECT: タスク完了\\\" with title \\\"Claude Code\\\" sound name \\\"Submarine\\\"\"; elif command -v paplay >/dev/null 2>&1; then paplay /usr/share/sounds/freedesktop/stereo/message.oga; fi"
           },
           {
             "type": "command",
@@ -132,7 +132,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "PROJECT=$(basename \"$PWD\"); if [ \"$(uname)\" = \"Darwin\" ]; then osascript -e \"display notification \\\"$PROJECT: 入力待ち\\\" with title \\\"Claude Code\\\" sound name \\\"Submarine\\\"\"; else paplay /usr/share/sounds/freedesktop/stereo/message.oga; fi"
+            "command": "PROJECT=$(basename \"$PWD\"); if [ \"$(uname)\" = \"Darwin\" ]; then osascript -e \"display notification \\\"$PROJECT: 入力待ち\\\" with title \\\"Claude Code\\\" sound name \\\"Submarine\\\"\"; elif command -v paplay >/dev/null 2>&1; then paplay /usr/share/sounds/freedesktop/stereo/message.oga; fi"
           },
           {
             "type": "command",

--- a/config/coding_agents/hooks/play-sound.sh
+++ b/config/coding_agents/hooks/play-sound.sh
@@ -3,6 +3,6 @@
 
 if [ "$(uname)" = "Darwin" ]; then
     afplay /System/Library/Sounds/Submarine.aiff
-else
+elif command -v paplay >/dev/null 2>&1; then
     paplay /usr/share/sounds/freedesktop/stereo/message.oga
 fi


### PR DESCRIPTION
## Summary

- `play-sound.sh` と Stop / Notification の inline hook が `paplay` 不在環境で no-op になるよう `command -v paplay` ガードを追加
- devcontainer (ubuntu base) で表示される `paplay: not found` のエラーログを抑止

## Why

devcontainer rebuild 後の Claude Code 起動で以下のエラーが出ていた:

```
Ran 3 stop hooks (ctrl+o to expand)
  ⎿  Stop hook error: Failed with non-blocking status code: /bin/sh: 1: paplay: not found
```

`config/coding_agents/claude/settings.json.erb` の Stop / Notification hook と `config/coding_agents/hooks/play-sound.sh` が Linux 分岐で paplay を無条件に呼んでおり、devcontainer (`mcr.microsoft.com/devcontainers/base:ubuntu`) には pulseaudio クライアントが入っていないため失敗していた。

PulseAudio を container に入れても、host への音は飛ばない（macOS の coreaudio に container 内の Linux からは届かない）ので、**container では sound hook を no-op にするのが正解**。host が Linux + PulseAudio のケースは引き続き動く。

## Test plan

- [x] `bash -n config/coding_agents/hooks/play-sound.sh`
- [ ] ganyu devcontainer で `mise run claude` 起動時に paplay エラーが出ないこと
- [ ] macOS host で通知音 (afplay) が引き続き鳴ること