### PR TITLE
fix(devcontainer): drop embedded quotes in codex args, add claude-sync-mcp shim

### DIFF
--- a/config/coding_agents/mcp.json.erb
+++ b/config/coding_agents/mcp.json.erb
@@ -39,8 +39,8 @@
       "command": "codex",
       "args": [
         "mcp-server",
-        "-c", "approval_policy=\"never\"",
-        "-c", "sandbox_mode=\"workspace-write\""
+        "-c", "approval_policy=never",
+        "-c", "sandbox_mode=workspace-write"
       ]
     }
   }

--- a/roles/base/default.rb
+++ b/roles/base/default.rb
@@ -90,6 +90,17 @@ end
 
 sync_user_mcp = File.join(root_dir, 'config/coding_agents/sync-claude-user-mcp.sh')
 
+# Expose the sync script as a re-runnable command. Claude Code's first OAuth
+# login can rewrite ~/.claude.json and drop the mcpServers populated here, so
+# users need a low-friction way to re-sync after login completes.
+directory "#{ENV['HOME']}/.local/bin" do
+  user node[:user] if node[:user]
+end
+
+link "#{ENV['HOME']}/.local/bin/claude-sync-mcp" do
+  to sync_user_mcp
+end
+
 execute 'sync ~/.mcp.json into claude user scope' do
   command "bash #{sync_user_mcp}"
   user node[:user] if node[:user]


### PR DESCRIPTION
## Summary

- ~/.mcp.json の codex MCP エントリで `-c` 引数値に埋め込みクォートを入れていたのを修正 (`approval_policy="never"` → `approval_policy=never`)。codex は bareword 値をそのまま受け入れるため、JSON 文字列に `\"` を残すと値側に余計な引用符が混入して MCP server 起動時のパラメータが期待外の文字列になっていた
- `~/.local/bin/claude-sync-mcp` シムを追加して `sync-claude-user-mcp.sh` を再実行可能にした。devcontainer の初回 OAuth ログインで Claude Code が `~/.claude.json` を書き直し、`mcpServers` を巻き戻すケースがあるため、ログイン後に低コストで再適用できる導線を用意

## Background

tyaba-env v0.22.1 (`fix/claude-dangerously-skip-permissions-in-container`) を生成した chrono に対する devcontainer 疎通検証で、Claude Code 初回起動 → OAuth ログイン後に `claude mcp list` が `{}` になる事象を確認した。原因切り分けの過程で次の二点を特定:

1. **codex args のクォーティング**: `mcp.json.erb` 上で `approval_policy=\"never\"` と書いていた。codex CLI / `mcp-server` の `-c` フラグは bareword 値を受け付ける形式で、JSON 経由で渡すと literal `"` が値側に残る
2. **mcpServers の上書き**: mitamae が `claude mcp add --scope user` を走らせるタイミングは OAuth ログイン前。ログイン後に Claude が `~/.claude.json` を再生成する経路で mcpServers が落ちることがあった

(2) の決定的な再現は取れなかったが、ユーザが再ログイン後にワンコマンドで再同期できる shim を提供しておけば運用上は十分に許容できると判断した。

## Test plan

- [ ] devcontainer rebuild → mitamae 完走 (`link` resource エラーが出ないこと)
- [ ] `cat ~/.mcp.json` で codex args の値に余計な `\"` が含まれていないことを確認
- [ ] `which claude-sync-mcp` が `~/.local/bin/claude-sync-mcp` を返すこと
- [ ] Claude Code 起動 → OAuth ログイン → `claude-sync-mcp` を実行 → `claude mcp list` で codex/yui/git/playwright/notion/slack/todoist/context7 が表示されること

## AI 監査

### Assumptions

- codex CLI の `-c` フラグは bareword 値 (`approval_policy=never`) を許容するという user-rules.md の記述を根拠とした。実機での挙動再現は次回 devcontainer rebuild 時に検証する
- mitamae の `link` resource は `to` 1 引数で symlink を作成できる (既存の `cookbooks/yui/default.rb:30` と `cookbooks/ssh-agent/default.rb:16` のパターンを踏襲)
- 既存 link 利用箇所は `user` パラメータも `force` パラメータも渡していないため、HOME 配下のリンクには不要と判断

### Intent Mapping

| ユーザー意図 | 解釈 | 実装 | 未考慮事項 |
|---|---|---|---|
| codex args の `\"` を取り除く | TOML override で値の埋め込みクォートを撤廃 | `mcp.json.erb` の 2 行を `=never` / `=workspace-write` に修正 | codex 側で逆に bareword をエラーにする変更が将来入る可能性 |
| OAuth login 後の mcpServers 巻き戻りに対する救済 | 自動化は副作用が読みにくいので、再実行用 shim 提供で妥協 | `~/.local/bin/claude-sync-mcp` → `config/coding_agents/sync-claude-user-mcp.sh` の symlink を mitamae で張る | 巻き戻り自体の根本原因 (Claude Code 内部の `~/.claude.json` 再生成シーケンス) は未調査 |

### Confidence

- codex クォーティング修正: **中** — 動作確認は次の devcontainer rebuild 待ち。user-rules.md の記述と整合
- claude-sync-mcp shim: **高** — 既存 sync スクリプトをそのまま再利用、副作用なし

### Behavior

- **Given** devcontainer 初回起動完了, **When** ユーザが `claude` で OAuth ログインしたあと `claude-sync-mcp` を実行, **Then** `~/.mcp.json` の全 mcpServers が Claude Code の user scope に再同期される
- **Given** codex MCP server を起動, **When** Claude Code が `~/.mcp.json` の args を渡す, **Then** codex は `approval_policy=never` を bareword として解釈し、起動パラメータに literal `"` が混入しない

### Code Changes

- `config/coding_agents/mcp.json.erb`: codex args の `\"` を撤廃
- `roles/base/default.rb`: `~/.local/bin` を作成、`claude-sync-mcp` symlink を追加