### PR TITLE
fix(devcontainer): pin global node before mise npm-backend installs

### DIFF
--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -68,6 +68,20 @@ end
 
 include_role 'base'
 
+# mise's npm backend (`mise use -g 'npm:...'`) shells out to `npm view` to
+# resolve the latest version. That call goes through the `npm` mise shim,
+# which needs an active node version to dispatch to. The dotfiles install.sh
+# runs mitamae from ~/dotfiles where no .mise.toml exists, so without a
+# globally-pinned node mise aborts with "No version is set for shim: npm"
+# and the downstream codex / claude installs both fail with a confusing
+# "No such file or directory (os error 2)" error.
+#
+# Pin an LTS node globally so npm-backend resolution works regardless of cwd.
+execute 'pin global node for mise npm backend' do
+  command 'mise use -g node@lts'
+  not_if 'mise current node >/dev/null 2>&1'
+end
+
 # Codex CLI is referenced by ~/.mcp.json (codex MCP server). Without it,
 # claude logs MCP startup errors on every launch.
 #


### PR DESCRIPTION
## Summary

- mitamae の \`execute\` リソース経由で走る \`mise use -g 'npm:...@latest'\` が、解決時に \`npm\` shim を叩く際に node が未設定で失敗する問題を修正
- \`roles/devcontainer/default.rb\` で codex / claude install の **前** に \`mise use -g node@lts\` を実行する step を追加

## Background

dotfiles を main HEAD まで進めて chrono の devcontainer rebuild を検証したところ、codex / claude いずれも install で次のエラーで失敗した:

\`\`\`
mise WARN  Failed to resolve tool version list for npm:@anthropic-ai/claude-code: [--runtime] npm:@anthropic-ai/claude-code@latest: No such file or directory (os error 2)
\`\`\`

実体は \`mise\` の \`npm:\` backend が version 解決のために \`npm view <pkg> dist-tags --json\` を呼ぶ過程で \`npm\` shim を辿るところ、cwd の \`.mise.toml\` ancestry に node version が見つからずに失敗していた:

\`\`\`
mise ERROR No version is set for shim: npm
Set a global default version with one of the following:
mise use -g node@20.20.2
\`\`\`

dotfiles install.sh の mitamae は \`~/dotfiles\` から実行されるため、project の \`.mise.toml\` (例: \`/workspaces/chrono/.mise.toml\`) には到達しない。global pin が必要。

## Test plan

- [x] container 内で \`mise use -g node@lts\` を手動実行後、\`sh -c 'mise use -g \"npm:@anthropic-ai/claude-code@latest\"'\` が成功することを確認済み (\`claude-cli 2.1.141\` install OK)
- [ ] devcontainer fresh rebuild → post-create.sh 完走 → \`which claude\`, \`which codex\` が \`~/.local/share/mise/shims/\` を返すこと

## AI 監査

### Assumptions

- \`mise use -g node@lts\` は \`lts\` 表記が現行 mise で解決できる前提 (実機検証で 24.15.0 が解決された)
- \`not_if 'mise current node >/dev/null 2>&1'\` で冪等性を担保。既に project 側 \`.mise.toml\` で node が active なら scrap
- 既存 \`include_role 'base'\` の後段で \`base\` recipe が node を要求していない (\`base\` は MCP テンプレート展開と sync スクリプト install のみ、node 不要)

### Intent Mapping

| ユーザー意図 | 解釈 | 実装 | 未考慮事項 |
|---|---|---|---|
| devcontainer rebuild で codex/claude install が失敗する事象を解消 | npm backend version 解決の前提崩れ。global node pin が必要 | \`roles/devcontainer/default.rb\` の codex install 直前に \`pin global node\` step を追加 | host の \`darwin\` role には影響しないが \`base\` role に node を要求する派生があれば衝突可能性 |

### Confidence

- 修正内容: **高** — 手動再現と修正後の手動成功を同一コンテナで確認済み

### Behavior

- **Given** devcontainer 起動直後 (mitamae 未走行), **When** \`./install.sh\` が走る, **Then** \`mise current node\` が解決可能になり、後続の codex/claude install が \`sh -c\` 経由でも成功する

### Code Changes

- \`roles/devcontainer/default.rb\`: codex install の **前** に \`execute 'pin global node for mise npm backend'\` を追加。\`not_if\` で project の \`.mise.toml\` が既に node を pin している場合は skip