### PR TITLE
feat(install): auto-detect devcontainer via /.dockerenv when DOTFILES_ROLE is unset

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,14 @@
 
 set -ex
 
+# Auto-detect devcontainer: /.dockerenv exists inside Docker containers
+# (VS Code Dev Containers and @devcontainers/cli both use Docker), so callers
+# no longer have to pass DOTFILES_ROLE explicitly. Explicit values still win.
+if [ -z "${DOTFILES_ROLE:-}" ] && [ -f /.dockerenv ]; then
+  DOTFILES_ROLE=devcontainer
+  export DOTFILES_ROLE
+fi
+
 # Resolve relative paths (bin/setup, bin/mitamae, lib/recipe.rb) against this
 # script's directory rather than the caller's cwd. Without this, calling
 # `$DOTFILES_DIR/install.sh` from elsewhere (e.g. a devcontainer


### PR DESCRIPTION
## Summary

`install.sh` 冒頭に `DOTFILES_ROLE` の auto-detect フォールバックを追加。`DOTFILES_ROLE` 未指定かつ `/.dockerenv` 存在時に `devcontainer` を自動付与する。明示指定された値は従来通り尊重される。

## 背景

呼び出し側 (`.devcontainer/post-create.sh` 等) が `env DOTFILES_ROLE=devcontainer` を渡し忘れると、`config/coding_agents/mcp.json.erb` が host 用にレンダされ、devcontainer 内から MCP に届かなくなる事故があった。

- **yui MCP**: `http://localhost:52981/mcp` → コンテナ内 localhost はホスト yui に届かない (本来は `host.docker.internal`)
- **git MCP** `command`: `~/.local/bin/uvx` → devcontainer に存在しない (本来は `~/.local/share/mise/shims/uvx`)

PR #19 / #20 で symptom 側 (mcp.json.erb の host 分岐) は整備済みだが、env var の付与漏れ自体は再発しうる。`install.sh` 側で根本的に救うのが本 PR の目的。

## 修正

`install.sh` の `set -ex` 直後 (`cd "$(dirname "$0")"` より前) に以下を挿入:

\`\`\`sh
if [ -z "\${DOTFILES_ROLE:-}" ] && [ -f /.dockerenv ]; then
  DOTFILES_ROLE=devcontainer
  export DOTFILES_ROLE
fi
\`\`\`

`/.dockerenv` は Docker container 内に必ず存在する Docker Engine 標準マーカで、VS Code Dev Containers / \`@devcontainers/cli\` どちらの経路でも作られる。

## 検証

- [x] \`sh -n install.sh\` で構文 OK
- [ ] chrono (or 他 devcontainer) を rebuild し、\`.devcontainer/post-create.sh\` から \`env DOTFILES_ROLE=...\` を**外しても** mcp.json が container 用にレンダされ、\`claude mcp list\` で yui / git が ✓ になることを実機確認
- [ ] host (macOS) は \`/.dockerenv\` 不在のためフォールバック不発動 → 従来通り host 用にレンダされる

## Follow-up

- tyaba-env テンプレ側 \`post-create.sh.jinja\` の明示付与 (\`env DOTFILES_ROLE=devcontainer ./install.sh\`) は二重防衛として残す方針
- Podman 等 \`/.dockerenv\` を作らないランタイムでは引き続き明示が必要 (現状利用無し)

## AI 監査

### Assumptions

- \`/.dockerenv\` は Docker container 起動時に Docker Engine が作る標準マーカで、ホスト (macOS / Linux) 上には基本存在しない
- 利用中の devcontainer はすべて Docker base (\`mcr.microsoft.com/devcontainers/base:ubuntu\` 等) のため \`/.dockerenv\` が確実に作られる
- \`DOTFILES_ROLE=devcontainer\` が現状 dotfiles 全体で「軽量 / no-sudo / MCP は container 用 host にレンダ」を意味する唯一の discriminator であり続ける前提

### Intent Mapping

| ユーザー意図 | 解釈 | 実装 | 未考慮事項 |
|---|---|---|---|
| devcontainer で env var の付与漏れによる MCP 接続不能を再発させたくない | 呼び出し側を信用せず install.sh 側でメタ検知してフォールバック | \`set -ex\` 直後に \`/.dockerenv\` 判定の自動付与ブロックを追加 | Docker 以外の container ランタイム (Podman / nerdctl etc.) では \`/.dockerenv\` 非対応の可能性 |

### Confidence

- 方針 (\`/.dockerenv\` 判定): **高** — Docker 標準仕様
- 非破壊性: **高** — \`-z "\${DOTFILES_ROLE:-}"\` で明示指定時は先に short-circuit
- POSIX sh 互換: **高** — \`[ -z ... ]\` / \`[ -f ... ]\` / \`&&\` はすべて POSIX

### Behavior

- **Given** install.sh が起動, **When** \`DOTFILES_ROLE\` 未指定 & \`/.dockerenv\` 存在, **Then** \`DOTFILES_ROLE=devcontainer\` が export され、後段の \`lib/recipe.rb\` / ERB が devcontainer 用にレンダされる
- **Given** install.sh が起動, **When** \`DOTFILES_ROLE=devcontainer\` を明示指定, **Then** \`-z\` チェックで先に short-circuit され、自動付与ブロックは no-op
- **Given** macOS host 上で install.sh を直叩き, **When** \`/.dockerenv\` 不在, **Then** フォールバック不発動 → 従来通り platform role (\`darwin\`) で実行

### Code Changes

- \`install.sh\`: \`set -ex\` 直後に 7 行のフォールバックブロックを追加。他ファイルは変更なし