### PR TITLE
fix(devcontainer): guard pin-node step on npm shim presence

### DIFF
--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -76,10 +76,11 @@ include_role 'base'
 # and the downstream codex / claude installs both fail with a confusing
 # "No such file or directory (os error 2)" error.
 #
-# Pin an LTS node globally so npm-backend resolution works regardless of cwd.
+# Pin and install an LTS node globally so the npm shim resolves to a real
+# runtime regardless of cwd.
 execute 'pin global node for mise npm backend' do
-  command 'mise use -g node@lts'
-  not_if 'mise current node >/dev/null 2>&1'
+  command 'mise use -g node@lts && mise install -y'
+  not_if 'mise which npm >/dev/null 2>&1'
 end
 
 # Codex CLI is referenced by ~/.mcp.json (codex MCP server). Without it,


### PR DESCRIPTION
## Summary

`DOTFILES_ROLE=devcontainer` の post-create で `mise use -g 'npm:@openai/codex@latest'` が `No such file or directory (os error 2)` で失敗する事象を修正する。

Follow-up to #17 (npm backend 切替)。#17 で導入した「pin global node for mise npm backend」ステップの `not_if` 判定が甘く、node 未 install の環境で skip されてしまうことが Tyaba/tyaba-env から `copier copy` で生成した non-nextjs スタックの devcontainer で発覚した。

## 原因

`roles/devcontainer/default.rb:80-83` の保険ステップ:

```ruby
execute 'pin global node for mise npm backend' do
  command 'mise use -g node@lts'
  not_if 'mise current node >/dev/null 2>&1'
end
```

`mise current node` は **global config に version が宣言されていれば exit 0 を返す**ため、devcontainer feature 側で node の設定だけ入って実体が install されていない状態でもこのステップが skip されてしまう。結果、後段の codex / claude install が npm shim を解決できず:

```
mise WARN  npm may be required but was not found.
mise WARN  Failed to resolve tool version list for npm:@openai/codex:
           [--runtime] npm:@openai/codex@latest: No such file or directory (os error 2)
mise ERROR Failed to install npm:@openai/codex@latest: No such file or directory (os error 2)
Command `mise use -g 'npm:@openai/codex@latest'` failed. (exit status: 1)
```

で落ちる。`include_nextjs=false` の tyaba-env プロジェクト (例: `mc-server`) では project 側 `.mise.toml` に node が含まれないため、dotfiles 側の保険ステップだけが node を確保する責務を持つ。その保険が機能不全になっていた。

## 変更

`roles/devcontainer/default.rb` の「pin global node for mise npm backend」ブロックを修正:

- `not_if` を `mise which npm >/dev/null 2>&1` に変更
  - `mise which` は shim → 実体の解決まで行うので、宣言だけあって install されていない状態を false 判定できる
- `command` を `mise use -g node@lts && mise install -y` に変更
  - `mise use` の autoinstall 挙動は version / shell context で揺れるため、`mise install -y` を明示して runtime を確実に materialize する
- 上部コメントも実体ベースで pin & install する旨を反映

## 代替案と却下理由

- `not_if 'command -v npm >/dev/null 2>&1'`: 動くが PATH に依存し、`~/.local/share/mise/shims` が role 冒頭で prepend されていることに暗黙依存する。`mise which` のほうが意図が明示的
- `mise current node` を維持して `mise install -y` だけ追加: skip 判定の甘さが残り、npm shim 不在のまま後段が落ちる経路を塞げない
- Tyaba/tyaba-env 側で `.mise.toml.jinja` に常時 `node = "lts"` を追加: 真因は dotfiles 側判定不備なので対症療法。node 不要なプロジェクトにも node を引かせるディスクコストもある

## Test plan

検証環境: tyaba-env から `copier copy` で生成した non-nextjs スタックの devcontainer (例: `mc-server`)。本 PR の branch を `~/dotfiles` で checkout し、`env DOTFILES_ROLE=devcontainer ./install.sh` を再走して確認する。

- [ ] mitamae の `execute[pin global node for mise npm backend]` が skip されず実行されることを確認
- [ ] `mise ls --installed` に `node <lts version>` が含まれる
- [ ] `mise which npm` が `~/.local/share/mise/installs/node/<ver>/bin/npm` を返す
- [ ] 後段の `execute[install codex cli (mise npm backend)]` / `execute[install claude code cli (mise npm backend)]` が完走
- [ ] `codex --version` / `claude --version` が応答する
- [ ] 再 run 時に `not_if 'mise which npm ...'` がヒットして skip されることを確認 (idempotency)
- [ ] node が project `.mise.toml` で pin 済みの環境 (nextjs スタック等) でも regression が無いことを確認