### PR TITLE
fix(devcontainer): seed ~/.claude.json with empty JSON object

### DIFF
--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -49,8 +49,10 @@ execute 'persist ~/.claude.json into ~/.claude/ volume' do
       fi
     fi
 
-    # Case 2: $TARGET still does not exist (fresh volume). Touch an empty file.
-    [ -e "$TARGET" ] || : > "$TARGET"
+    # Case 2: $TARGET is missing or empty (fresh volume, or a stale empty
+    # file from a previous bug). Initialize with a valid JSON object so
+    # Claude Code does not abort with "Unexpected EOF" on first launch.
+    [ -s "$TARGET" ] || printf '{}\n' > "$TARGET"
 
     # Case 3: Ensure $LINK is a symlink pointing to $TARGET.
     if [ -L "$LINK" ]; then


### PR DESCRIPTION
## Summary

devcontainer 初回 build 時に Claude Code が `Configuration Error / JSON Parse error: Unexpected EOF` で onboarding loop に陥る事象を修正する。

Follow-up to #29 (pin-node の `not_if` 厳密化)。#29 merge 後の rebuild 検証で claude 起動時に新たに発覚した。

## 原因

`roles/devcontainer/default.rb` の `persist ~/.claude.json into ~/.claude/ volume` execute ブロック、Case 2 のシェルロジック:

```bash
# Case 2: $TARGET still does not exist (fresh volume). Touch an empty file.
[ -e "$TARGET" ] || : > "$TARGET"
```

新規 named volume では `$TARGET=~/.claude/.claude.json` を **0 バイト** で作成する。`~/.claude.json` はそこへの symlink なので、claude が初回起動で空文字を `JSON.parse("")` しようとして:

```
Configuration Error
The configuration file at /home/vscode/.claude.json contains invalid JSON.
JSON Parse error: Unexpected EOF
Choose an option:
❯ 1. Exit and fix manually
```

で onboarding loop に陥る。post-create.sh の `verify claude install` は `claude --version` の出力で成功扱いになるため CI ログ上は通って見え、後段の `mise.toml` task `claude` 起動時に初めて顕在化する罠つき。

## 変更

Case 2 のシェルロジックを修正:

- 存在チェック `[ -e ]` → 「サイズ > 0」チェック `[ -s ]`
  - 以前のバグで作られた 0 バイトファイルが残っている rebuild も heal 対象に含める
- 空 truncate `: > "\$TARGET"` → 有効 JSON object 初期化 `printf '{}\n' > "\$TARGET"`

コメントも `Touch an empty file` から `Initialize with a valid JSON object` に置き換え、意図変更を残す。Case 1 (host 側ファイル migration) / Case 3 (symlink ensure) は変更なし。

## 代替案と却下理由

- `[ -e "\$TARGET" ] || printf '{}\n' > "\$TARGET"`: `-e` のままだと既に 0 バイトの実体ファイルがある rebuild ケースを heal できない。`-s` に倒したほうが defensive
- claude 側の起動エラーを catch して reset させる: 上流 (Claude Code 本体) のロジック頼みでこちらでは制御不能
- post-create.sh の `verify claude install` で空ファイル検出: 責務が分散する。symlink を作る当事者側で初期化するのが最もシンプル

## Test plan

検証環境: tyaba-env から `copier copy` で生成した devcontainer (例: `mc-server`)。本 PR の branch を `~/dotfiles` で checkout し、`env DOTFILES_ROLE=devcontainer ./install.sh` を再走、もしくは claude-code-config volume を rm してから devcontainer rebuild して確認する。

- [ ] mitamae の `execute[persist ~/.claude.json into ~/.claude/ volume]` 内で `~/.claude/.claude.json` が `{}\n` で初期化される
- [ ] `~/.claude.json` が `~/.claude/.claude.json` への symlink になっている
- [ ] `claude --version` がエラー無く応答する
- [ ] devcontainer 内で `claude` を起動しても onboarding loop に入らず、Configuration Error が出ない
- [ ] 既存 setup (volume に有効な `.claude.json` が残る環境) で content が上書きされないことを確認 (`-s` ガードで skip)
- [ ] 旧バグの遺物として 0 バイト `~/.claude/.claude.json` が残っている環境でも heal される