### PR TITLE
fix(devcontainer): re-sync MCP into claude user scope after claude install

### DIFF
--- a/roles/devcontainer/default.rb
+++ b/roles/devcontainer/default.rb
@@ -106,3 +106,22 @@ execute 'install claude code cli (mise npm backend)' do
   command "mise use -g 'npm:@anthropic-ai/claude-code@latest'"
   not_if 'mise which claude >/dev/null 2>&1'
 end
+
+# Re-run the user-scope MCP sync after the claude CLI is installed.
+#
+# The base role attempts this earlier, but at that point this role has not
+# yet installed `claude` (steps below `include_role 'base'`), so
+# sync-claude-user-mcp.sh exits silently via its `command -v claude` guard.
+# Without this re-run, devcontainers boot with an empty user-scope
+# mcpServers list until the user invokes `claude-sync-mcp` manually.
+#
+# Note: Claude Code's first OAuth login still rewrites ~/.claude.json and
+# may drop user-scope mcpServers. `claude-sync-mcp` remains the documented
+# manual recovery path after onboarding completes.
+sync_user_mcp = File.expand_path('../../../config/coding_agents/sync-claude-user-mcp.sh', __FILE__)
+
+execute 'sync ~/.mcp.json into claude user scope (post claude install)' do
+  command "bash #{sync_user_mcp}"
+  user node[:user] if node[:user]
+  only_if 'command -v claude'
+end


### PR DESCRIPTION
## Summary

新規 devcontainer の post-create 完了直後に、Claude Code の MCP リストが **context7 (外部経由) しか入っていない** 状態になる事象を修正する。

Follow-up to #29 / #30。#30 merge 後の rebuild 検証で onboarding を通った先で発覚した独立バグ。

## 原因

`roles/devcontainer/default.rb` の実行順:

```
① persist ~/.claude.json into ~/.claude/ volume
② include_role 'base'
    └─ execute 'sync ~/.mcp.json into claude user scope'
         └─ bash config/coding_agents/sync-claude-user-mcp.sh
              ↑ ここで claude mcp add --scope user を呼ぼうとするが、
                claude CLI は未 install なので
                `if ! command -v claude; ... exit 0` で silent skip
③ pin global node for mise npm backend
④ install codex cli (mise npm backend)
⑤ install claude code cli (mise npm backend)  ← ここで初めて claude 利用可能
                                                 でも sync は再走しない
```

結果、`~/.claude.json` の user scope `mcpServers` が空になり、Claude Code の MCP リストには claude.ai 経由で入る context7 だけが残る (`~/.mcp.json` 内の git / playwright / notion / slack / todoist / yui / codex は全部欠落)。

`sync-claude-user-mcp.sh` のコメント (lines 6-9) にもある通り、devcontainer では cwd ancestor walk が `/workspaces` で止まり `~/.mcp.json` も読まれないため、user scope に同期する経路だけが唯一の供給ルート。それが skip されると Claude Code には dotfiles 由来の MCP が一切見えない。

base role の sync execute 自体は user re-run 用の `claude-sync-mcp` symlink セットの目的があり、その位置で動くこと自体は意図通り。devcontainer 固有の追加処理として **claude install 後に再度 sync を流す** 必要があった。

## 変更

`roles/devcontainer/default.rb` の末尾、`install claude code cli (mise npm backend)` execute の後ろに、sync を再実行する execute を追加:

```ruby
sync_user_mcp = File.expand_path('../../../config/coding_agents/sync-claude-user-mcp.sh', __FILE__)

execute 'sync ~/.mcp.json into claude user scope (post claude install)' do
  command "bash #{sync_user_mcp}"
  user node[:user] if node[:user]
  only_if 'command -v claude'
end
```

要点:
- `__FILE__` ベースで sync スクリプトの絶対パスを解決 (base role の `root_dir` ローカル変数はスコープが分離されているため、ここで再計算)
- `only_if 'command -v claude'` で claude が依然見えない場合は no-op に倒す (壊さない方が優先)
- `user node[:user] if node[:user]` は base role と同じ nil-guard パターン

## 代替案と却下理由

- **base role の execute を `only_if 'command -v claude'` でガードして 1 回目を no-op に**: noop 化はできるが結局 claude install 後に sync が走らないので問題が解決しない。devcontainer 側の追加 execute は依然必要
- **claude install を `include_role 'base'` より **前** に動かす**: base role が `~/.codex/AGENTS.md` 等の codex 設定を書き、それを参照する codex CLI install もまた base 依存。順序を入れ替えると別の循環依存が出る
- **sync を post-create.sh の最後に bash で直接実行**: mitamae 外で実行すると mitamae の冪等性チェーンから外れる。同じ install.sh 内で sync の状態を保証するには mitamae に乗せたほうが筋がいい

## Test plan

検証環境: tyaba-env から `copier copy` で生成した devcontainer (例: `mc-server`)。claude-code-config volume を rm してから rebuild、もしくは本 PR の branch を `~/dotfiles` で checkout し `env DOTFILES_ROLE=devcontainer ./install.sh` を再走して確認する。

- [ ] mitamae log で `execute[sync ~/.mcp.json into claude user scope (post claude install)]` が実行されること (skip でないこと)
- [ ] `claude mcp list --scope user` (もしくは Claude Code 起動後の `/mcp`) で git / playwright / notion / slack / todoist / yui / codex / context7 がすべて表示される
- [ ] 既存 setup (volume に有効な `.claude.json` が残る環境) で regression 無し
- [ ] OAuth login 後の rewrite ケースは別経路 (`claude-sync-mcp` 手動実行) で復旧することを引き続き確認
- [ ] base role 側の 1 回目の sync が silent skip するだけで、log に大きな noise を撒かないことを確認

### 補足

- onboarding 後の OAuth login で `~/.claude.json` が rewrite され user-scope mcpServers が drop されるケースは別の制約として残る。これは `~/.local/bin/claude-sync-mcp` を手動実行することで復旧する設計
- ただし devcontainer.json の `remoteEnv.PATH` に `~/.local/bin` が含まれていない問題が別途あり、`claude-sync-mcp` が PATH 解決できない。これは tyaba-env 側で対応予定 (Follow-up PR)