### PR TITLE
fix(hooks): allow `terraform apply <plan_file>` in terraform-apply-guard

### DIFF
--- a/config/coding_agents/hooks/terraform-apply-guard.sh
+++ b/config/coding_agents/hooks/terraform-apply-guard.sh
@@ -145,22 +145,8 @@ esac
 
 # ── Layer 3: plan content inspection ──
 
-plan_cmd=("$tf_bin")
-[ -n "$chdir_opt" ] && plan_cmd+=("$chdir_opt")
-if [ "$subcommand" = "destroy" ]; then
-  plan_cmd+=(plan -destroy -json -input=false)
-else
-  plan_cmd+=(plan -json -input=false)
-fi
-plan_cmd+=("${sub_args[@]+"${sub_args[@]}"}")
-
 stderr_file=$(mktemp -t tf-guard-stderr.XXXXXX)
 trap 'rm -f "$stderr_file"' EXIT
-
-if ! plan_output=$("${plan_cmd[@]}" 2>"$stderr_file"); then
-  stderr=$(cat "$stderr_file" 2>/dev/null || true)
-  emit_deny "terraform plan failed. Blocking $subcommand for safety.$([ -n "$stderr" ] && echo " stderr: $stderr")"
-fi
 
 STATEFUL_PATTERNS=(
   "google_bigquery_"
@@ -174,18 +160,71 @@ STATEFUL_PATTERNS=(
 )
 pattern_regex=$(IFS="|"; echo "${STATEFUL_PATTERNS[*]}")
 
-violations=$(echo "$plan_output" \
-  | jq -r '
-    select(.type == "planned_change")
-    | .change
-    | select(.resource)
-    | .resource.resource_type as $type
-    | .resource.resource_name as $name
-    | .action as $action
-    | select($action == "delete" or $action == "replace")
-    | "\($type).\($name) (\($action))"
-  ' 2>/dev/null \
-  | grep -E "$pattern_regex" || true)
+plan_file=""
+if [ "${#sub_args[@]}" -gt 0 ]; then
+  for arg in "${sub_args[@]}"; do
+    case "$arg" in
+      -*) ;;
+      *)
+        candidate_path="$arg"
+        case "$candidate_path" in
+          /*) ;;
+          *) candidate_path="$tf_cwd/$candidate_path" ;;
+        esac
+        if [ -f "$candidate_path" ]; then
+          plan_file="$arg"
+          break
+        fi
+        ;;
+    esac
+  done
+fi
+
+if [ -n "$plan_file" ]; then
+  show_cmd=("$tf_bin")
+  [ -n "$chdir_opt" ] && show_cmd+=("$chdir_opt")
+  show_cmd+=(show -json "$plan_file")
+
+  if ! plan_output=$("${show_cmd[@]}" 2>"$stderr_file"); then
+    stderr=$(cat "$stderr_file" 2>/dev/null || true)
+    emit_deny "terraform show -json failed for plan file. Blocking $subcommand for safety.$([ -n "$stderr" ] && echo " stderr: $stderr")"
+  fi
+
+  violations=$(echo "$plan_output" \
+    | jq -r '
+      .resource_changes[]?
+      | select(.change.actions[] | . == "delete" or . == "replace")
+      | "\(.type).\(.name) (\(.change.actions | join(",")))"
+    ' 2>/dev/null \
+    | grep -E "$pattern_regex" || true)
+else
+  plan_cmd=("$tf_bin")
+  [ -n "$chdir_opt" ] && plan_cmd+=("$chdir_opt")
+  if [ "$subcommand" = "destroy" ]; then
+    plan_cmd+=(plan -destroy -json -input=false)
+  else
+    plan_cmd+=(plan -json -input=false)
+  fi
+  plan_cmd+=("${sub_args[@]+"${sub_args[@]}"}")
+
+  if ! plan_output=$("${plan_cmd[@]}" 2>"$stderr_file"); then
+    stderr=$(cat "$stderr_file" 2>/dev/null || true)
+    emit_deny "terraform plan failed. Blocking $subcommand for safety.$([ -n "$stderr" ] && echo " stderr: $stderr")"
+  fi
+
+  violations=$(echo "$plan_output" \
+    | jq -r '
+      select(.type == "planned_change")
+      | .change
+      | select(.resource)
+      | .resource.resource_type as $type
+      | .resource.resource_name as $name
+      | .action as $action
+      | select($action == "delete" or $action == "replace")
+      | "\($type).\($name) (\($action))"
+    ' 2>/dev/null \
+    | grep -E "$pattern_regex" || true)
+fi
 
 if [ -n "$violations" ]; then
   reason="Blocked: stateful resource destroy/replace detected in terraform $subcommand plan:"

--- a/config/coding_agents/hooks/terraform-apply-guard.sh
+++ b/config/coding_agents/hooks/terraform-apply-guard.sh
@@ -162,8 +162,16 @@ pattern_regex=$(IFS="|"; echo "${STATEFUL_PATTERNS[*]}")
 
 plan_file=""
 if [ "${#sub_args[@]}" -gt 0 ]; then
+  prev_flag_takes_value=false
   for arg in "${sub_args[@]}"; do
+    if [ "$prev_flag_takes_value" = true ]; then
+      prev_flag_takes_value=false
+      continue
+    fi
     case "$arg" in
+      -var-file|-state|-state-out|-backup|-target|-var|-replace|-out|-parallelism|-lock-timeout)
+        prev_flag_takes_value=true
+        ;;
       -*) ;;
       *)
         candidate_path="$arg"


### PR DESCRIPTION
## Summary

- `terraform apply <plan_file>` 形式の呼び出しが hook (`terraform-apply-guard.sh`) で **plan failed = deny** と誤判定される不具合を修正
- plan file を `sub_args` から検出した場合は `terraform [-chdir=...] show -json <plan_file>` 経由で plan の JSON 表現を取得し、`.resource_changes[]` を走査して stateful destroy/replace を検査する
- plan file を指定しない既存パターン (`terraform apply` / `terraform destroy`) は **既存ロジックを else 枝に温存**

Closes #32

## Why

Layer 3 (plan 内容検査) は `sub_args` をそのまま `terraform plan -json -input=false` に引き継ぐ実装だったため、`terraform apply tfplan` のとき `terraform plan -json -input=false tfplan` という Terraform CLI として無効なコマンドラインが組み立てられ、plan が失敗 → hook 全体で deny されていた。

`terraform show -json <plan_file>` を使えば既に確定した plan の JSON を再 plan なしで取得できる。出力スキーマは `plan -json` の streaming `planned_change` JSON-Lines と異なり `.resource_changes[]` の単一 JSON になるため、jq 整形を経路ごとに分岐させている (stateful resource フィルタ用の `STATEFUL_PATTERNS` / `pattern_regex` は両経路で共通)。

副次効果として、plan file 経路では `terraform plan` を二度走らせる無駄もなくなる。

## Implementation notes

- `sub_args` 走査時の plan file 検出は「`-` で始まらないトークン」かつ「`tf_cwd` 基準で実在ファイル」のもの (Issue #32 推奨案 1 に準拠)
- `terraform show -json` 失敗時は既存形式に揃えて `emit_deny "terraform show -json failed for plan file. Blocking ... stderr: ..."`
- `set -u` 配慮で `sub_args` が空のときに走査ループに入らないよう `[ "${#sub_args[@]}" -gt 0 ]` でガード
- `stderr_file` の `mktemp` / `trap` は両経路で共有するため Layer 3 冒頭に移動

## Test plan

- [x] `bash -n config/coding_agents/hooks/terraform-apply-guard.sh` — 構文 OK
- [x] `shellcheck config/coding_agents/hooks/terraform-apply-guard.sh` — warning なし
- [ ] mc-server リポジトリで `terraform plan -out=tfplan` → Claude Code から `terraform apply tfplan` が **通る** ことを確認
- [ ] 同リポジトリで `google_storage_bucket` の destroy/replace を含む plan を作成 → `terraform apply tfplan` が **deny** されることを確認 (Layer 3 が plan-file 経路でも機能していることの確認)
- [ ] plan file を指定しない `terraform apply` / `terraform destroy` が従来どおり動作することを確認 (既存ロジック温存の回帰確認)
- [ ] main ブランチ上で `terraform apply tfplan` が Layer 2 で先に止まることを確認

## 関連

- 誤って tyaba-env に投稿した issue (Tyaba/tyaba-env#91) は本 PR とは別途クローズ
