### PR TITLE
chore(coding_agents): consolidate MCP connectors onto claude.ai (slack/notion/unused connectors)

### DIFF
--- a/config/coding_agents/claude/settings.json.erb
+++ b/config/coding_agents/claude/settings.json.erb
@@ -25,7 +25,9 @@
       "mcp__yui__*",
       "mcp__playwright__*",
       "mcp__todoist__*",
-      "mcp__codex__*"
+      "mcp__codex__*",
+      "mcp__claude_ai_Notion__*",
+      "mcp__claude_ai_SlackDB__*"
     ],
     "deny": [
       "Read(*credentials.json)",

--- a/config/coding_agents/claude/settings.json.erb
+++ b/config/coding_agents/claude/settings.json.erb
@@ -23,7 +23,6 @@
       "WebFetch(*)",
       "WebSearch(*)",
       "mcp__yui__*",
-      "mcp__slack__*",
       "mcp__playwright__*",
       "mcp__todoist__*",
       "mcp__notion__*",
@@ -62,6 +61,9 @@
   },
   "model": "opus",
   "enabledMcpjsonServers": [],
+  "deniedMcpServers": [
+    { "serverUrl": "https://mcp.slack.com/*" }
+  ],
   "hooks": {
     "SessionStart": [
       {

--- a/config/coding_agents/claude/settings.json.erb
+++ b/config/coding_agents/claude/settings.json.erb
@@ -25,7 +25,6 @@
       "mcp__yui__*",
       "mcp__playwright__*",
       "mcp__todoist__*",
-      "mcp__notion__*",
       "mcp__codex__*"
     ],
     "deny": [

--- a/config/coding_agents/claude/settings.json.erb
+++ b/config/coding_agents/claude/settings.json.erb
@@ -26,6 +26,13 @@
       "mcp__playwright__*",
       "mcp__todoist__*",
       "mcp__codex__*",
+      "mcp__claude_ai__*",
+      "mcp__claude_ai_Excalidraw__*",
+      "mcp__claude_ai_Figma__*",
+      "mcp__claude_ai_Gmail__*",
+      "mcp__claude_ai_Google_Calendar__*",
+      "mcp__claude_ai_Google_Cloud_BigQuery__*",
+      "mcp__claude_ai_Google_Drive__*",
       "mcp__claude_ai_Notion__*",
       "mcp__claude_ai_SlackDB__*"
     ],

--- a/config/coding_agents/claude/settings.json.erb
+++ b/config/coding_agents/claude/settings.json.erb
@@ -62,7 +62,23 @@
   "model": "opus",
   "enabledMcpjsonServers": [],
   "deniedMcpServers": [
-    { "serverUrl": "https://mcp.slack.com/*" }
+    { "serverUrl": "https://mcp.slack.com/*" },
+    { "serverUrl": "https://mcp.canva.com/*" },
+    { "serverUrl": "https://mcp.heygen.com/*" },
+    { "serverUrl": "https://mcp.asana.com/*" },
+    { "serverUrl": "https://mcp.clickup.com/*" },
+    { "serverUrl": "https://mcp.monday.com/*" },
+    { "serverUrl": "https://mcp.atlassian.com/*" },
+    { "serverUrl": "https://microsoft365.mcp.claude.com/*" },
+    { "serverUrl": "https://mcp.box.com/*" },
+    { "serverUrl": "https://cyberagent-lodeo.snowflakecomputing.com/*" },
+    { "serverUrl": "https://tableau-mcp.cyberagent.group/*" },
+    { "serverUrl": "https://api.salesforce.com/platform/mcp/v1/analytics/tableau-next*" },
+    { "serverUrl": "https://listeningmind-service-mcp.ascentlab.io/*" },
+    { "serverUrl": "https://mcp.hubspot.com/*" },
+    { "serverUrl": "https://mcp.app.wiz.io/*" },
+    { "serverUrl": "https://mcp.zapier.com/*" },
+    { "serverUrl": "https://cyberagent-talentbank.snowflakecomputing.com/*" }
   ],
   "hooks": {
     "SessionStart": [

--- a/config/coding_agents/mcp.json.erb
+++ b/config/coding_agents/mcp.json.erb
@@ -11,10 +11,6 @@
         "@playwright/mcp@latest"
       ]
     },
-    "notion": {
-      "type": "http",
-      "url": "https://mcp.notion.com/mcp"
-    },
     "todoist": {
       "type": "http",
       "url": "https://ai.todoist.net/mcp"

--- a/config/coding_agents/mcp.json.erb
+++ b/config/coding_agents/mcp.json.erb
@@ -15,14 +15,6 @@
       "type": "http",
       "url": "https://mcp.notion.com/mcp"
     },
-    "slack": {
-      "type": "http",
-      "url": "https://mcp.slack.com/mcp",
-      "oauth": {
-        "clientId": "1601185624273.8899143856786",
-        "callbackPort": 3118
-      }
-    },
     "todoist": {
       "type": "http",
       "url": "https://ai.todoist.net/mcp"


### PR DESCRIPTION
## Summary
- Drop the personal `slack` MCP entry and switch to the `claude.ai SlackDB` connector instead.
- Drop the personal `notion` MCP entry now that the `claude.ai Notion` connector is available.
- Add a `deniedMcpServers` block (`serverUrl` form) to suppress claude.ai connectors we do not use: Slack, Canva, Heygen, Asana, ClickUp, monday.com, Atlassian, Microsoft 365, Box, HubSpot, Wiz, Zapier, Tableau (both flavours), ListeningMind, and CyberAgent-specific endpoints.
- Extend `permissions.allow` with `mcp__claude_ai_Notion__*`, `mcp__claude_ai_SlackDB__*`, and the rest of the authenticated `claude.ai_*` tool prefixes so each call does not require a fresh permission prompt.

## Test plan
- [x] `./install.sh` renders `~/.claude/settings.json` without lint errors (`Settings Error` is gone).
- [x] `claude mcp list` shows the kept connectors as connected and no longer surfaces the denied ones.
- [x] Personal `slack` / `notion` MCP entries are removed from `~/.mcp.json`.