### PR TITLE
fix(coding_agents): drop stale user-scope MCP entries during sync

### DIFF
--- a/config/coding_agents/sync-claude-user-mcp.sh
+++ b/config/coding_agents/sync-claude-user-mcp.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # This sync keeps config/coding_agents/mcp.json.erb as the single source of truth.
 
 MCP_JSON="${MCP_JSON:-$HOME/.mcp.json}"
+USER_CONFIG="${USER_CONFIG:-$HOME/.claude.json}"
 
 log() {
   echo "[sync-claude-user-mcp] $*" >&2
@@ -28,6 +29,20 @@ fi
 if [ ! -f "$MCP_JSON" ]; then
   log "warning: $MCP_JSON not found; skipping"
   exit 0
+fi
+
+# Remove user-scope entries that no longer exist in $MCP_JSON. Without this,
+# servers dropped from mcp.json.erb stay registered in the user scope forever,
+# causing duplicates next to claude.ai connectors (e.g. a leftover "notion"
+# stdio entry shadowing the official Notion connector).
+if [ -f "$USER_CONFIG" ]; then
+  expected_names=$(jq -r '.mcpServers // {} | keys[]?' "$MCP_JSON" | sort -u)
+  current_names=$(jq -r '.mcpServers // {} | keys[]?' "$USER_CONFIG" | sort -u)
+  while IFS= read -r stale; do
+    [ -z "$stale" ] && continue
+    log "removing stale user-scope $stale"
+    claude mcp remove --scope user "$stale" >/dev/null 2>&1 || true
+  done < <(comm -23 <(echo "$current_names") <(echo "$expected_names"))
 fi
 
 while IFS= read -r row; do


### PR DESCRIPTION
## Summary
- `sync-claude-user-mcp.sh` previously only added entries from `~/.mcp.json` and never removed anything from the user scope.
- Servers removed from `mcp.json.erb` (e.g. the personal `notion` stdio entry replaced by the `claude.ai Notion` connector) kept lingering in `~/.claude.json`, producing duplicate listings in `claude mcp list`.
- Diff `$MCP_JSON` against the `mcpServers` keys in `~/.claude.json` and `claude mcp remove --scope user` anything that is no longer expected before the existing add loop runs.

## Test plan
- [x] `claude mcp list` no longer shows the duplicate `notion` entry (existing drift was also cleaned with `claude mcp remove --scope user notion`).
- [x] Re-running the script with no drift is a no-op besides the usual sync logs.
- [x] Dropping an arbitrary entry from `~/.mcp.json` and re-running the script removes it from `~/.claude.json`.
- [x] `bash -n` passes.
