### PR TITLE
chore(mise): add @devcontainers/cli as a managed tool

### DIFF
--- a/config/mise/config.toml.erb
+++ b/config/mise/config.toml.erb
@@ -8,6 +8,7 @@ pnpm = "latest"
 flutter = "latest"
 ruby = "latest"
 go = "latest"
+"npm:@devcontainers/cli" = "latest"
 
 [settings]
 experimental = true


### PR DESCRIPTION
## Summary
- `config/mise/config.toml.erb` の `[tools]` に `"npm:@devcontainers/cli" = "latest"` を追加し、ホスト側の `devcontainer` CLI を mise 管理下に置く。
- tyaba-env テンプレートが生成する `.mise.toml` の `[tasks."claude"]` が `devcontainer up --workspace-folder .` を呼ぶが、`@devcontainers/cli` を入れる場所がどこにもなく、node 再インストール等のたびに `command not found` で詰まっていた問題の恒久対応。

## Why npm backend
- node を切り替えても tool ごとに独立した install を持つため消えない。
- `mise install` で新規マシンでも自動セットアップされる。

## Test plan
- [x] ローカルで `mise use -g "npm:@devcontainers/cli@latest"` 実行後 `devcontainer --version` が `0.87.0` を返すことを確認
- [ ] mitamae 再適用後も `~/.config/mise/config.toml` に当該行が反映され `devcontainer` が PATH に乗ることを確認