### PR TITLE
fix(ssh): guard macOS-only UseKeychain with IgnoreUnknown

### DIFF
--- a/config/.ssh/darwin.config
+++ b/config/.ssh/darwin.config
@@ -1,4 +1,8 @@
 Host *
+  # UseKeychain is macOS-only. Guard it so this config stays parseable on
+  # Linux OpenSSH (e.g. when this file is bind-mounted into a Linux
+  # devcontainer); unknown keywords would otherwise abort every ssh call.
+  IgnoreUnknown UseKeychain
   AddKeysToAgent yes
   UseKeychain yes
   RemoteForward 24713 localhost:4713


### PR DESCRIPTION
## 概要

`config/.ssh/darwin.config` の `Host *` ブロックに `IgnoreUnknown UseKeychain` を追加した。`UseKeychain` は macOS 専用オプションのため、同じ設定ファイルを Linux の OpenSSH が読むと SSH 接続自体が失敗するのを防ぐため。

## 背景・目的

`UseKeychain yes` は Apple の OpenSSH フォーク専用のオプションで、上流（Linux ディストリ同梱）の OpenSSH には存在しない。Linux 側の `ssh` がこのキーワードを読むと `Bad configuration option: usekeychain` で**起動時に異常終了**し、その config を使う全 SSH 接続（git push 含む）が通らなくなる。

この問題は、tyaba-env テンプレートの devcontainer がホストの `~/.ssh`（macOS で生成され、本リポジトリ由来の `UseKeychain yes` を含む）を Linux コンテナへ bind mount する際に顕在化する（tyaba-env PR #117 で `~/.ssh` マウントを追加）。コンテナ内で SSH remote へ push しようとすると、`UseKeychain` 行のせいで `ssh` が即死する。

`IgnoreUnknown <keyword>` は上流 OpenSSH（7.x 以降）がサポートするディレクティブで、指定した未知キーワードのパースエラーを抑止する。`UseKeychain` より前の同一 `Host` ブロック内に置く必要がある。これにより:

- macOS: `UseKeychain` は既知のため実質 no-op（従来どおり Keychain 連携が効く）
- Linux: `UseKeychain` を未知扱いで黙って無視し、config 全体が parseable に保たれる

## 変更内容

- `config/.ssh/darwin.config`: `Host *` ブロックの先頭に `IgnoreUnknown UseKeychain` と説明コメントを追加。

## 影響範囲

- macOS の挙動は不変（`IgnoreUnknown` は既知オプションには影響しない）。
- Linux で本 config を読む経路（devcontainer への bind mount 等）で SSH が通るようになる。
- 後方互換性の破壊なし。

## 補足（このPRだけでは閉じない点）

- 本リポジトリには `base.config` / `darwin.config` を `~/.ssh/config` へ展開する mitamae recipe が見当たらず、実機の `~/.ssh/config` は手管理の実ファイル（gcloud `config-ssh` 生成分も混在）になっている。そのため**このPRをマージしても既存ホストの `~/.ssh/config` は自動更新されない**。
- 当面コンテナで SSH push を通すには、実機の `~/.ssh/config` の `Host *` にも同じ `IgnoreUnknown UseKeychain` 行を手で入れる必要がある。
- 別途、config 断片を `~/.ssh/config` へ配置する recipe の整備（または手管理である旨の明文化）は follow-up とする。

## テスト

### テスト項目

- [ ] macOS で `ssh -G github.com` がエラーなく解決する（UseKeychain 反映を確認）
- [ ] Linux（devcontainer）で同 config を読ませ `ssh -G github.com` がエラーを出さない
- [ ] devcontainer 内で SSH remote リポジトリへ push できる

### テスト結果

```bash
# 未実施（実機 devcontainer 再ビルドでの確認が必要）
```