### PR TITLE
feat(ssh): manage ~/.ssh/config.d via Include directive

### DIFF
--- a/config/.ssh/base.config
+++ b/config/.ssh/base.config
@@ -1,7 +1,0 @@
-Host *
-    IdentityFile ~/.ssh/id_ed25519
-    ForwardAgent yes
-    ForwardX11 yes
-
-Host *cyberagent*
-    User yoshino_teppei

--- a/config/.ssh/config.d/00-base.config
+++ b/config/.ssh/config.d/00-base.config
@@ -1,0 +1,18 @@
+# Cross-platform SSH defaults.
+#
+# Loaded first via the `Include ~/.ssh/config.d/*.config` line that the
+# dotfiles `ssh` cookbook ensures at the top of ~/.ssh/config. Include globs
+# are processed in lexical order, so this 00- file is read before 10-darwin.
+#
+# IgnoreUnknown must stay at the very top of the first Host block: it
+# suppresses parse errors for the listed keywords wherever they appear *after*
+# it, including macOS-only options such as UseKeychain that get read by Linux
+# OpenSSH (e.g. when ~/.ssh is bind-mounted into a Linux devcontainer).
+Host *
+    IgnoreUnknown UseKeychain
+    IdentityFile ~/.ssh/id_ed25519
+    ForwardAgent yes
+    ForwardX11 yes
+
+Host *cyberagent*
+    User yoshino_teppei

--- a/config/.ssh/config.d/10-darwin.config
+++ b/config/.ssh/config.d/10-darwin.config
@@ -1,0 +1,9 @@
+# macOS-only SSH options.
+#
+# Symlinked only by the darwin role. The IgnoreUnknown guard in
+# 00-base.config (loaded first) keeps UseKeychain harmless if this file is ever
+# read by Linux OpenSSH, e.g. via a bind-mounted ~/.ssh in a devcontainer.
+Host *
+    AddKeysToAgent yes
+    UseKeychain yes
+    RemoteForward 24713 localhost:4713

--- a/config/.ssh/darwin.config
+++ b/config/.ssh/darwin.config
@@ -1,4 +1,0 @@
-Host *
-  AddKeysToAgent yes
-  UseKeychain yes
-  RemoteForward 24713 localhost:4713

--- a/cookbooks/ssh/default.rb
+++ b/cookbooks/ssh/default.rb
@@ -1,0 +1,40 @@
+# Deploy SSH client config fragments under ~/.ssh/config.d/ and wire them in
+# via a single `Include` line at the top of ~/.ssh/config.
+#
+# ~/.ssh/config itself is intentionally NOT symlinked or templated: it holds
+# host-specific entries and gcloud `config-ssh`-generated blocks that must stay
+# local (and may differ per machine). We own only the portable fragments and
+# the Include line; everything else in ~/.ssh/config is left untouched.
+#
+# Included by the real-machine roles (darwin / ubuntu / debian), NOT by the
+# devcontainer role: in a devcontainer ~/.ssh is a readonly bind mount of the
+# host, so writing here would fail and is unnecessary — the container reads the
+# host-generated config (which already Includes these fragments) directly.
+
+dotfile '.ssh/config.d/00-base.config'
+
+dotfile '.ssh/config.d/10-darwin.config' if node[:platform] == 'darwin'
+
+# Idempotently ensure ~/.ssh/config pulls in the fragments. The Include is
+# prepended so the fragment defaults (notably IgnoreUnknown) are parsed before
+# any pre-existing inline options.
+execute 'ensure ~/.ssh/config Includes config.d fragments' do
+  command <<~SH
+    set -eu
+    ssh_dir="$HOME/.ssh"
+    config="$ssh_dir/config"
+    line='Include ~/.ssh/config.d/*.config'
+    mkdir -p "$ssh_dir"
+    chmod 700 "$ssh_dir"
+    if [ ! -e "$config" ]; then
+      printf '%s\n' "$line" > "$config"
+      chmod 600 "$config"
+    elif ! grep -qxF "$line" "$config"; then
+      tmp="$(mktemp)"
+      { printf '%s\n\n' "$line"; cat "$config"; } > "$tmp"
+      cat "$tmp" > "$config"
+      rm -f "$tmp"
+    fi
+  SH
+  user node[:user] if node[:user]
+end

--- a/roles/darwin/default.rb
+++ b/roles/darwin/default.rb
@@ -30,6 +30,7 @@ include_cookbook 'fzf'
 include_cookbook 'git'
 include_cookbook 'mise'
 include_cookbook 'go'
+include_cookbook 'ssh'
 # 開発系
 include_cookbook 'emacs'
 include_cookbook 'ghq'

--- a/roles/ubuntu/default.rb
+++ b/roles/ubuntu/default.rb
@@ -20,6 +20,7 @@ include_cookbook 'fzf'
 include_cookbook 'git'
 include_cookbook 'mise'
 include_cookbook 'go'
+include_cookbook 'ssh'
 # 開発系
 include_cookbook 'ripgrep'
 include_cookbook 'emacs'


### PR DESCRIPTION
## 概要

SSH クライアント設定を「`Include ~/.ssh/config.d/*.config` で断片を取り込む」方式に移行し、dotfiles が portable な共通設定だけを管理できるようにした。`~/.ssh/config` 本体（host 固有エントリや gcloud 生成ブロック、機密寄りの設定）は引き続きローカル管理のまま、共通デフォルトのみテンプレ化するのが目的。

## 背景・目的

これまで `config/.ssh/base.config` / `config/.ssh/darwin.config` は存在したが、**`~/.ssh/config` へ展開する recipe が無く、実機の config は完全な手管理**だった。その結果:

- dotfiles 側の断片は dead file 化していた（symlink も concat も Include も無し）。
- macOS 専用の `UseKeychain yes` がガードされておらず、この設定を **Linux の OpenSSH が読むと `Bad configuration option: usekeychain` で ssh が起動時に異常終了**する。tyaba-env テンプレートの devcontainer がホスト `~/.ssh` を Linux コンテナへ bind mount する経路（tyaba-env #117）で、git push 等の全 SSH 接続が壊れる。

## このPRで何ができるようになるか

darwin/ubuntu/debian の実機で dotfiles を install すると、`~/.ssh/config` の先頭に Include 行が冪等に挿入され、portable な共通設定が config.d 経由で適用される。

```sh
# install 後の ~/.ssh/config（先頭に1行だけ挿入。既存内容は保持）
$ head -1 ~/.ssh/config
Include ~/.ssh/config.d/*.config

# Linux OpenSSH でもパースエラーにならない（UseKeychain は IgnoreUnknown で無視）
$ ssh -G github.com >/dev/null && echo OK
OK
```

## 変更内容

- `config/.ssh/config.d/00-base.config`（新規, 旧 `base.config` 相当 + ガード追加）: クロスプラットフォーム共通設定。`Host *` ブロック先頭に `IgnoreUnknown UseKeychain`(後続の未知キーワードのパースエラーを抑止する OpenSSH 7.x+ のディレクティブ)を追加。Include glob は lexical 順で読まれるため 00- が最初に評価され、ガードが後続全体（10-darwin や手管理側の `UseKeychain`）に効く。
- `config/.ssh/config.d/10-darwin.config`（新規, 旧 `darwin.config` 相当）: macOS 専用設定（`UseKeychain` / `RemoteForward` / `AddKeysToAgent`）。darwin ロールでのみ symlink。
- `config/.ssh/base.config` / `config/.ssh/darwin.config`（削除）: 上記 config.d へ移動。
- `cookbooks/ssh/default.rb`（新規）: 断片を `~/.ssh/config.d/` へ symlink し、`Include ~/.ssh/config.d/*.config` を `~/.ssh/config` の先頭へ冪等に prepend する（既存内容は非破壊）。`mkdir -p ~/.ssh && chmod 700` も実施。
- `roles/darwin/default.rb` / `roles/ubuntu/default.rb`（変更）: `include_cookbook 'ssh'` を追加（debian は ubuntu を include するため自動的に対象）。

## 設計上の判断

| 検討した選択肢 | 採用 / 不採用 | 理由 |
|---|---|---|
| `Include` で config.d 断片を取り込む（本PR） | 採用 | 機密寄りの host 固有/gcloud 生成エントリをローカルに残しつつ、共通設定だけテンプレ管理できる。冪等な1行挿入で既存 config を壊さない |
| `~/.ssh/config` 自体を symlink/テンプレ化 | 不採用 | gcloud `config-ssh` が同ファイルへ追記するため、repo に機密が漏れる/symlink が破壊される |
| `ssh` cookbook を base ロールに入れる | 不採用 | base は devcontainer ロールからも include される。devcontainer の `~/.ssh` は readonly bind mount のため書き込みが失敗する。実機ロール限定にした |
| darwin 断片のガードのみ修正（#43） | 不採用（本PRで supersede） | 配線が無いので実機 config に届かず、根本解決にならない |

## AI 監査

### Assumptions（明示指示なしで仮定したこと）

- `IgnoreUnknown UseKeychain` を darwin 断片ではなく 00-base 側の先頭に置いた。根拠: Include glob は lexical 順で 00 が先に読まれ、IgnoreUnknown は宣言以降の全パースに効くため、手管理側に残る inline な `UseKeychain` も同時にガードできる。違っていたら: ガード対象を darwin 断片内に限定する。
- `AddKeysToAgent` は元の `darwin.config` にあった配置を踏襲し 10-darwin に置いた（Linux 実機の挙動を従来どおりに保つため）。クロスプラットフォーム化が望ましければ 00-base へ移動する。
- ssh cookbook を darwin/ubuntu に追加した（debian は ubuntu 経由）。実機 Linux ロールにも共通設定を効かせる意図。不要なら darwin 限定に絞る。

### 自信の弱い箇所（要レビュー）

- `cookbooks/ssh/default.rb` の Include prepend を `execute` + shell で実装した。mitamae の `user node[:user]`(= `sudo -H -u`)配下で `$HOME` が対象ユーザーに解決されることに依存している。既存 recipe 群と同じ前提だが、実機 install での冪等性（2回流して差分が出ないこと）は実機確認したい。
- Linux OpenSSH 上での `IgnoreUnknown` 抑止は理屈上正しいが、macOS 上でしか `ssh -G` 検証できていない（下記）。

### 振る舞い（具体例ベース）

#### ケース 1: 既存 ~/.ssh/config への冪等な Include 挿入

```
# Given: ~/.ssh/config が手管理で存在し Include 行が無い
# When:  ssh cookbook を2回流す
# Then:  1回目で先頭に "Include ~/.ssh/config.d/*.config" が1行挿入され、既存内容は保持。2回目は grep -qxF で検知し no-op
```

#### ケース 2: Linux コンテナでの UseKeychain ガード

```
# Given: macOS host の ~/.ssh が Linux devcontainer に bind mount され、config.d/10-darwin.config に UseKeychain yes がある
# When:  コンテナ内で ssh github.com
# Then:  00-base の IgnoreUnknown UseKeychain により UseKeychain が無視され、ssh はパースエラーなく接続する
```

### コード構造の変更

```mermaid
flowchart LR
    R["roles/darwin・ubuntu (実機ロール)"] -->|"include_cookbook 'ssh'"| C["cookbooks/ssh/default.rb"]
    C -->|"symlink"| F1["~/.ssh/config.d/00-base.config (共通)"]
    C -->|"symlink (darwinのみ)"| F2["~/.ssh/config.d/10-darwin.config (macOS専用)"]
    C -->|"冪等 prepend"| CFG["~/.ssh/config (手管理・非破壊)"]
    CFG -->|"Include glob (lexical順)"| F1
    CFG --> F2
    DC["roles/devcontainer (readonly mount)"] -.->|"ssh cookbook を含めない"| C
```

## 影響範囲

- darwin/ubuntu/debian 実機で次回 install 時に Include 行が挿入される。既存 config は非破壊（1行 prepend のみ）。
- devcontainer ロールは対象外（readonly mount のため）。コンテナは host 生成済み config を読むだけ。
- **既存 host の `~/.ssh/config` は recipe 再実行までは更新されない**。今すぐコンテナで SSH push を通したい場合は、手で先頭に `Include ~/.ssh/config.d/*.config` を入れるか install を再実行する。
- 後方互換: macOS の挙動は不変（`IgnoreUnknown` は既知オプションに無影響）。

## テスト

### テスト項目

- [x] `ruby -c` で cookbook / 変更ロールの構文確認
- [x] config.d 断片を結合し macOS `ssh -G` でパース成功を確認
- [ ] Linux 実機/コンテナで `ssh -G` がパースエラーを出さないことを確認
- [ ] darwin 実機で install を2回流し Include 挿入が冪等であることを確認

### テスト結果

```bash
$ ruby -c cookbooks/ssh/default.rb roles/darwin/default.rb roles/ubuntu/default.rb
Syntax OK (x3)

$ # 一時dirに config.d を配置し Include する config を作成して
$ ssh -F "$tmp/.ssh/config" -G github.com >/dev/null && echo "parse OK (macOS)"
parse OK (macOS)
```