### PR TITLE
chore(coding_agents): switch from internal SlackDB to official Slack MCP

### DIFF
--- a/config/coding_agents/claude/settings.json.erb
+++ b/config/coding_agents/claude/settings.json.erb
@@ -34,7 +34,8 @@
       "mcp__claude_ai_Google_Cloud_BigQuery__*",
       "mcp__claude_ai_Google_Drive__*",
       "mcp__claude_ai_Notion__*",
-      "mcp__claude_ai_SlackDB__*"
+      "mcp__claude_ai_SlackDB__*",
+      "mcp__claude_ai_Slack__*"
     ],
     "deny": [
       "Read(*credentials.json)",
@@ -77,7 +78,6 @@
   # Entries whose host itself reveals internal product names are kept in
   # config/coding_agents/private/denied_mcp_servers.json.
   public_denied_mcp_servers = [
-    { "serverUrl" => "https://mcp.slack.com/*" },
     { "serverUrl" => "https://mcp.canva.com/*" },
     { "serverUrl" => "https://mcp.heygen.com/*" },
     { "serverUrl" => "https://mcp.asana.com/*" },


### PR DESCRIPTION
## What

Move Claude Code's Slack access from the internal SlackDB connector to the official Slack connector.

`config/coding_agents/claude/settings.json.erb`:
- Add `mcp__claude_ai_Slack__*` to `permissions.allow`
- Remove `https://mcp.slack.com/*` from `public_denied_mcp_servers`

## Why

The internal connector only covers a subset of the Slack workspaces I need. The official Slack connector authenticates against my own account and covers the rest.

## Note on disabling the internal connector

Disabling the internal connector is handled by its `serverUrl` in `config/coding_agents/private/denied_mcp_servers.json` (gitignored), so that change is not part of this diff.

Rationale for the URL-based form: `deniedMcpServers` `serverName` is constrained to `[A-Za-z0-9_-]+`, so display names containing spaces or dots fail schema validation. Matching by `serverUrl` avoids that, consistent with #40.

## Verification

Rendered the ERB with the private denied list merged and validated the output:
- JSON valid
- official Slack tool present in `allow`
- `https://mcp.slack.com/*` no longer denied
- internal connector URL present in the denied list (via the private file)
