### PR TITLE
chore(coding_agents): add Codex disconnection as offload exception

### DIFF
--- a/config/coding_agents/user-rules.md
+++ b/config/coding_agents/user-rules.md
@@ -41,6 +41,7 @@
 - MCP を活用した外部サービス連携（yui / Slack / Notion / Todoist 等）
 - **手続き型ワークフローのオーケストレーション**: TDD サイクルのフェーズ進行判断とフェーズ間の検証・コミット、`pr-template` 等のテンプレに沿った PR description 組み立て、DDD レイヤー確認、DB マイグレーション手順管理など。個別フェーズ内のコード変更は Codex に移譲してよい
 - **PR description / commit message 等の文章組み立て**（テンプレ準拠が必要なため Claude が書く）
+- **Codex の疎通が取れない場合**: `mcp__codex__codex` ツールが利用不可な環境 (CI 上の Claude Code Action / 一時的な認証切れ / MCP サーバ障害等)。この場合は Claude 自身が `Edit` / `Write` を直接実行する。コスト要因 (Anthropic API 従量) は発生するが品質縮退ではない
 - ユーザーが明示的に「自分で書いて」と指示したとき
 
 それ以外（バグ調査・修正、テスト作成、lint 修正、ドキュメント生成、単一機能実装、CI 失敗調査、stuck 検知）は Codex。


### PR DESCRIPTION
## 背景

`user-rules.md` の「Codex オフロード」原則は「コード変更を伴うタスクはデフォルトで `mcp__codex__codex` に移譲する」と規定しているが、**Codex MCP が物理的に呼べない環境**での扱いが暗黙化していた。

具体的には以下のケースで Claude が「Codex に移譲するべきか / 自分で `Edit` するべきか」を都度判断しなければならず、ルール解釈の揺れが生じる:

- **CI 上の Claude Code Action**: `mcp__codex__codex` が MCP として登録されていない (tyaba-env の `claude.yml.jinja` で動く Claude が該当)
- **一時的な認証切れ**: Codex CLI の認証期限切れ等で `mcp__codex__codex` 呼び出しが失敗する
- **MCP サーバ障害**: Codex プロセスが落ちている等で疎通不可

これらは tyaba-env Phase 3-A (claude.yml.jinja を AIDD 3 ジョブ構造に書き直す PR、https://github.com/Tyaba/tyaba-env/pull/136) の機能設計レビューで顕在化した論点で、`P3 escalation #4` として議論済。ご主人様判断で「CI 限定の特殊ルールではなく、Codex 疎通不可一般の例外として一般化する」方針を採用した。

## 変更内容

`config/coding_agents/user-rules.md` の「Claude に残すタスク (例外のみ)」リストに 1 項目追加:

```diff
 - **PR description / commit message 等の文章組み立て**（テンプレ準拠が必要なため Claude が書く）
+- **Codex の疎通が取れない場合**: `mcp__codex__codex` ツールが利用不可な環境 (CI 上の Claude Code Action / 一時的な認証切れ / MCP サーバ障害等)。この場合は Claude 自身が `Edit` / `Write` を直接実行する。コスト要因 (Anthropic API 従量) は発生するが品質縮退ではない
 - ユーザーが明示的に「自分で書いて」と指示したとき
```

## 採用しなかった選択肢

| 選択肢 | 不採用理由 |
|---|---|
| tyaba-env 側の ADR (`docs/adr/0002-claude-yml-3-jobs.md`) と `aidd-construction` skill 両方に「CI では Codex 利用不可」を明記する | CI 限定の特殊ルールになり、ローカル一時障害ケースをカバーできない。同じ判断を 2 箇所に分散させると同期コストも発生 |
| tyaba-env 側の ADR のみに記載 | 同上、ローカル障害ケース未対応 |
| Codex MCP を CI 環境にも組み込む別 PR を起案 | Codex CLI の CI runner 動作・認証・stability の検証コストが大きく、本論点 (ルール解釈の揺れ解消) とは別軸 |

## スコープ外（意図的に変更しない）

- Codex オフロードの**他の判定条件** (前段ルール優先、Claude に残すタスクの既存項目) は無改変
- tyaba-env 側の `aidd-construction` skill / ADR への記載追加なし (本 PR の `user-rules.md` 1 箇所更新で代替)
- Codex MCP を CI に組み込む試み (別軸の検討事項)
- `cookbooks/traefik/default.rb` の未コミット変更 (本 PR と無関係なため除外)

## 関連

- tyaba-env Phase 3-A PR: https://github.com/Tyaba/tyaba-env/pull/136 (P3 escalation #4)

## テスト

ルール (Markdown) のみの変更。動作検証は次回 Codex 疎通不可な状況 (CI 実行 / 認証切れ時) で Claude が `Edit` / `Write` を直接行えるか観察する。
