### PR TITLE
fix(mise): install codex via mise npm backend so it survives node upgrades

### DIFF
--- a/config/mise/config.toml.erb
+++ b/config/mise/config.toml.erb
@@ -9,6 +9,7 @@ flutter = "latest"
 ruby = "latest"
 go = "latest"
 "npm:@devcontainers/cli" = "latest"
+"npm:@openai/codex" = "latest"
 
 [settings]
 experimental = true

--- a/cookbooks/claude/default.rb
+++ b/cookbooks/claude/default.rb
@@ -28,8 +28,9 @@ end
   end
 end
 
-# Codex CLI (used as MCP server via `codex mcp-server`)
-execute 'install codex cli' do
-  command 'npm install -g @openai/codex'
-  not_if 'which codex'
-end
+# Codex CLI (MCP server via `codex mcp-server`) is installed by the mise npm
+# backend declared in config/mise/config.toml.erb, not here. A plain
+# `npm install -g` was fragile: npm globals are per-node-version, so a node bump
+# (e.g. 20 -> 24) orphaned codex while the leftover mise shim let
+# `not_if 'which codex'` skip the reinstall, leaving `codex mcp-server` dead.
+# mise pins codex independently of the active node, surviving node upgrades.


### PR DESCRIPTION
## 背景

ホスト (macOS) で codex MCP (`codex mcp-server`) が**定期的に起動できなくなる**問題を調査した。認証は無傷 (`codex login status` → Logged in using ChatGPT、access_token も有効・refresh_token で自動更新) で**再ログインは不要**。真因は環境配線側にあった。

codex はこれまで `cookbooks/claude/default.rb` の `npm install -g @openai/codex` で**アクティブな node のグローバル**に入れていた。しかし:

- **npm global は node バージョンごと**に独立しているため、グローバル node を `20` → `24` に昇格させた時点で codex が引き継がれず消滅する
- それでも `~/.local/share/mise/shims/codex` の残骸 shim が PATH に残るため、`not_if 'which codex'` が成功扱いになり mitamae が**再インストールをスキップ**する
- 結果、`codex mcp-server` 起動時に mise が `No version is set for shim: codex` を返して即死し、Claude Code から codex MCP が見えなくなる

#41 で `@devcontainers/cli` を mise 管理下に移したのと同じ問題・同じ恒久対応。

## 変更内容

### `config/mise/config.toml.erb`

- `[tools]` に `"npm:@openai/codex" = "latest"` を追加し、codex を mise の npm backend 管理下に置く

### `cookbooks/claude/default.rb`

- 脆かった `execute 'install codex cli'` (`npm install -g` + `not_if 'which codex'`) を**削除**し、codex は mise config で管理する旨をコメントで明示

## なぜ mise npm backend か

- node を切り替えても tool ごとに独立した install (`installs/npm-openai-codex/`) を持つため消えない
- `mise install` で新規マシンでも自動セットアップされる
- `not_if 'which codex'` の残骸 shim 誤判定問題が原理的に発生しない

## 採用しなかった選択肢

| 選択肢 | 不採用理由 |
|---|---|
| `mise use -g 'npm:@openai/codex@latest'` を host role の execute として追加 | `~/.config/mise/config.toml` は template で都度再生成されるため、宣言は erb (正本) に置くのが正しい。execute だと二重管理になる |
| `npm install -g` のまま `not_if` を `command -v codex && codex --version` 等に強化 | node 昇格で消える根本問題が残る。shim 誤判定を回避しても再発する |
| codex のバージョンを固定 (`@0.139.0` 等) | 既存の他 npm tool (`@devcontainers/cli`) と揃え `latest` 運用。固定は更新追従コストが増える |

## スコープ外（意図的に変更しない）

- **破損していた `~/.codex/state_5.sqlite` の修復**: 別件の SQLite 破損 (disk image malformed) で codex の state runtime 初期化も失敗していたが、これは local state の問題で本 PR (インストール配線) とは別軸。`state_5.sqlite.corrupt.bak` に退避して codex に再生成させる対応をローカルで実施済み (auth.json とは別物なのでログインは維持)
- **破損の原因と推測される `~/.codex` の readonly bind mount**: devcontainer 側の設定で、正本は tyaba-env テンプレート。本リポジトリ外
- **`roles/devcontainer/default.rb` の codex install** (`mise use -g`): devcontainer は毎回クリーンに作り直すため host 問題とは性質が異なり、無改変

## 関連

- #41 `chore(mise): add @devcontainers/cli as a managed tool` (同型の先行対応)

## テスト

```bash
# config 同期 + インストール (mise cookbook 相当)
mise install
mise which codex              # => ~/.local/share/mise/installs/npm-openai-codex/latest/bin/codex
codex --version               # => codex-cli 0.139.0
codex login status            # => Logged in using ChatGPT
codex mcp-server </dev/null   # => state runtime 初期化 OK、version エラー無し
```

適用後の確認項目:

- [x] `mise install` で codex が node24 非依存パスに入り `mise which codex` で解決
- [x] `codex --version` → `codex-cli 0.139.0`、`codex login status` → Logged in (認証維持)
- [x] `codex mcp-server` が `No version is set for shim` を出さず起動
- [ ] `./install.sh` (mitamae 再適用) 後も `~/.config/mise/config.toml` に当該行が反映され、node 昇格後も codex が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
