### PR TITLE
fix(traefik): drop group attr to avoid UNKNOWN group on AD-integrated macOS

### DIFF
--- a/cookbooks/traefik/default.rb
+++ b/cookbooks/traefik/default.rb
@@ -5,27 +5,27 @@ case node[:platform]
 when 'darwin'
   directory proxy_dir do
     owner node[:user] if node[:user]
-    group node[:group] if node[:group]
+    # group node[:group]  # AD-integrated macOS resolves group to "UNKNOWN"; rely on owner only
     mode '0755'
   end
 
   directory certs_dir do
     owner node[:user] if node[:user]
-    group node[:group] if node[:group]
+    # group node[:group]  # AD-integrated macOS resolves group to "UNKNOWN"; rely on owner only
     mode '0755'
   end
 
   remote_file "#{proxy_dir}/docker-compose.yaml" do
     source 'files/docker-compose.yaml'
     owner node[:user] if node[:user]
-    group node[:group] if node[:group]
+    # group node[:group]  # AD-integrated macOS resolves group to "UNKNOWN"; rely on owner only
     mode '0644'
   end
 
   remote_file "#{proxy_dir}/traefik.yaml" do
     source 'files/traefik.yaml'
     owner node[:user] if node[:user]
-    group node[:group] if node[:group]
+    # group node[:group]  # AD-integrated macOS resolves group to "UNKNOWN"; rely on owner only
     mode '0644'
   end
 


### PR DESCRIPTION
## 背景 / 問題

AD連携の CyberAgent 管理 Mac で `mise run` (mitamae) を実行すると、traefik レシピが以下で失敗する。

```
ERROR : stderr | chown: UNKNOWN: illegal group name
ERROR : Command `chown s17536:UNKNOWN /Users/s17536/.tyaba/proxy/docker-compose.yaml` failed. (exit status: 1)
ERROR : remote_file[/Users/s17536/.tyaba/proxy/docker-compose.yaml] Failed.
```

## 原因

AD連携環境では mitamae の `node[:group]` がグループ名へ解決できず、リテラル文字列 `"UNKNOWN"` にフォールバックする。その結果 `group node[:group]` を指定したリソースが `chown s17536:UNKNOWN` を実行し、存在しないグループ名のため失敗してレシピが中断する。

## 修正

`cookbooks/traefik/default.rb` の 4箇所の `group node[:group] if node[:group]` をコメントアウトし、`owner` のみ指定する形にした。これは既存の `ssh-agent` / `gpg-agent` / `ssh` cookbook と同じパターンで、同一の AD 連携 mitamae 制約を回避するための確立された方法。`group` を省略しても、対象ファイル/ディレクトリは実行プロセスの実 GID で書かれるため実害はない。

## テスト

- AD連携 Mac で `mise run` 相当を再実行し、traefik レシピが `chown ... illegal group name` を出さずに完走することを確認する。