### PR TITLE
fix(dnsmasq): make restart idempotent to stop per-apply sudo prompts

### DIFF
--- a/cookbooks/dnsmasq/default.rb
+++ b/cookbooks/dnsmasq/default.rb
@@ -1,7 +1,10 @@
 case node[:platform]
 when 'darwin'
+  # dnsmasq は $(brew --prefix)/sbin に入り、PATH に sbin が無い環境では which が常に失敗する。
+  # which 判定だと install が毎回実行扱いになり restart 通知が毎回飛ぶため、brew list で判定する。
   execute 'brew install dnsmasq' do
-    not_if 'which dnsmasq'
+    not_if 'brew list dnsmasq >/dev/null 2>&1'
+    notifies :run, 'execute[restart dnsmasq]', :delayed
   end
 
   execute 'mkdir -p "$(brew --prefix)/etc/dnsmasq.d"' do
@@ -11,6 +14,7 @@ when 'darwin'
   execute 'configure dnsmasq for .test wildcard' do
     command 'printf "%s\n" "address=/test/127.0.0.1" > "$(brew --prefix)/etc/dnsmasq.d/tyaba-test.conf"'
     not_if 'test -f "$(brew --prefix)/etc/dnsmasq.d/tyaba-test.conf" && grep -qx "address=/test/127.0.0.1" "$(brew --prefix)/etc/dnsmasq.d/tyaba-test.conf"'
+    notifies :run, 'execute[restart dnsmasq]', :delayed
   end
 
   execute 'create /etc/resolver/test for .test wildcard' do
@@ -18,10 +22,17 @@ when 'darwin'
     not_if 'test -f /etc/resolver/test && grep -q "nameserver 127.0.0.1" /etc/resolver/test'
   end
 
-  # brew services restart は停止中でも起動するため idempotent。conf 更新時に毎回 reload する目的で not_if は付けない。
-  # sudo の secure_path に /opt/homebrew/bin が含まれない環境向けに $(which brew) でフルパスを解決。
-  execute 'sudo brew services restart dnsmasq' do
+  # restart は install または conf 更新の通知時だけ遅延実行し、定常状態では sudo を呼ばない。
+  # sudo の secure_path に Homebrew の bin が含まれない環境向けに $(which brew) でフルパスを解決する。
+  # root サービスの状態は非 sudo の brew services list では正しく判定できないため、停止判定には pgrep -x dnsmasq を使う。
+  execute 'start dnsmasq if stopped' do
+    command "sudo \"$(which brew)\" services start dnsmasq"
+    not_if 'pgrep -x dnsmasq'
+  end
+
+  execute 'restart dnsmasq' do
     command "sudo \"$(which brew)\" services restart dnsmasq"
+    action :nothing
   end
 else
   raise NotImplementedError


### PR DESCRIPTION
## 背景 / 問題

`cookbooks/dnsmasq/default.rb` を mitamae で適用するたびに sudo パスワードを要求されていた。

```
INFO :   execute[brew install dnsmasq] executed will change from 'false' to 'true'
INFO :   execute[sudo brew services restart dnsmasq] executed will change from 'false' to 'true'
```

原因は 2 つ:

1. **restart が無条件実行** — 最後の `execute 'sudo brew services restart dnsmasq'` にガードが無く、毎回実行されて sudo を要求していた（主因）。
2. **install ガードが常に失敗** — `not_if 'which dnsmasq'` は dnsmasq が `$(brew --prefix)/sbin` に入りログインシェルでも PATH に `sbin` が含まれないため常に失敗し、install リソースが毎回「実行」扱いになっていた。元コードでは restart が無条件だったため目立たなかったが、通知駆動化すると「install が毎回 restart を通知 → 毎回 sudo」となり修正が無意味になる隠れた地雷。

## 変更内容

- restart を `execute 'restart dnsmasq'` + `action :nothing` の **通知駆動** に変更。
- `brew install dnsmasq` と `configure dnsmasq for .test wildcard` の両リソースに `notifies :run, 'execute[restart dnsmasq]', :delayed` を付与し、実際に install / conf が変わったときだけ restart する。
- install ガードを `not_if 'brew list dnsmasq >/dev/null 2>&1'`（bin/sbin 非依存）に変更。
- 停止時起動用に `execute 'start dnsmasq if stopped'`（`not_if 'pgrep -x dnsmasq'`）を追加。restart が無条件でなくなったため。root として登録した brew services は非 sudo の `brew services list` が status を誤表示するため、起動判定には `pgrep` を使用。

## 挙動

| 状況 | sudo |
|---|---|
| 何も変わらない（インストール済・conf一致・起動中） | 呼ばれない（全スキップ） |
| conf 更新 / 新規インストール | restart 通知で最大 1 回 |
| dnsmasq が停止していた | start で最大 1 回 |

## 検証

- mitamae **v1.14.0** が `notifies`/`subscribes` に対応していることを最小レシピで実証。`not_if` でスキップされたリソースは通知を飛ばさないことも確認。
- `ruby -c` 構文 OK。
- `sudo -k` でキャッシュをクリアした実機 real run（定常状態）で、全リソースがスキップ・**sudo 呼び出しゼロ・exit 0**・dnsmasq 無変更（PID 維持）を確認。