### PR TITLE
feat(aqua-voice): add Aqua Voice cask for macOS

### DIFF
--- a/cookbooks/aqua-voice/default.rb
+++ b/cookbooks/aqua-voice/default.rb
@@ -1,0 +1,8 @@
+case node[:platform]
+when 'darwin'
+  execute 'brew install --cask aqua-voice' do
+    not_if 'test -d "/Applications/Aqua Voice.app"'
+  end
+else
+  raise NotImplementedError
+end

--- a/cookbooks/aqua-voice/default.rb
+++ b/cookbooks/aqua-voice/default.rb
@@ -1,7 +1,10 @@
 case node[:platform]
 when 'darwin'
+  # /Applications/Aqua Voice.app の有無で判定すると、Caskroom に記録が残ったまま
+  # app だけ手動削除されたケースで brew が upgrade 扱いになり置換元が無くて失敗する。
+  # Caskroom 登録の有無で判定する。
   execute 'brew install --cask aqua-voice' do
-    not_if 'test -d "/Applications/Aqua Voice.app"'
+    not_if 'brew list --cask aqua-voice >/dev/null 2>&1'
   end
 else
   raise NotImplementedError

--- a/roles/darwin/default.rb
+++ b/roles/darwin/default.rb
@@ -16,6 +16,7 @@ include_cookbook 'vlc'
 include_cookbook 'zoom'
 include_cookbook 'xquartz'
 include_cookbook 'linear'
+include_cookbook 'aqua-voice'
 ## 状況把握
 include_cookbook 'htop'
 include_cookbook 'cursor'


### PR DESCRIPTION
## Summary
- Add a new cookbook `aqua-voice` that installs Aqua Voice via `brew install --cask aqua-voice` on darwin.
- Include the cookbook from `roles/darwin/default.rb` (mac GUI tools section) so it ships only on macOS.

## Test plan
- [ ] Run the darwin role on a Mac and confirm `/Applications/Aqua Voice.app` is installed.
- [ ] Re-run the role and confirm the install step is skipped (idempotent via `not_if`).